### PR TITLE
chore: add dependabot.yaml

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    reviewers:
+      - "ukorvl"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -5,7 +5,7 @@ const Configuration = {
   formatter: "@commitlint/format",
   rules: {
     "header-max-length": [2, "always", 72],
-    "subject-case": [2, "always", ["sentence-case"]],
+    "subject-case": [2, "always", ["sentence-case", "lower-case"]],
     "subject-full-stop": [2, "never", "."],
     "type-enum": [
       2,
@@ -23,7 +23,8 @@ const Configuration = {
         "revert",
       ],
     ],
-    "type-case": [2, "always", "lower-case"]
+    "type-case": [2, "always", "lower-case"],
+    "body-max-line-length": [0],
   },
   helpUrl:
     "https://github.com/conventional-changelog/commitlint/#what-is-commitlint",


### PR DESCRIPTION
This diff adjusts commitlint rules to fit dependabot commits, and adds `dependabot.yaml` to add some settings to dependabot pull requests. 