### PR TITLE
feat: add markers examples

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -12,6 +12,11 @@ inputs:
     required: false
     default: "/"
     type: "string"
+  deploy:
+    description: "Build the project for deployment"
+    required: false
+    default: false
+    type: "boolean"
 
 runs:
   using: "composite"
@@ -36,8 +41,11 @@ runs:
     - name: Build
       run: |
         export VITE_BASE_URL=${{ inputs.base-path }}
-        export VITE_PUBLISH_COMMIT_URL=https://github.com/${{ github.repository }}/commit/${{ github.sha }}
-        export VITE_SITE_PUBLISHED_TIMESTAMP=$(date -u +"%Y-%m-%d")
+
+        if [ ${{ inputs.deploy }} = true ]; then
+          export VITE_PUBLISH_COMMIT_URL=https://github.com/${{ github.repository }}/commit/${{ github.sha }}
+          export VITE_SITE_PUBLISHED_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        fi
 
         npm run build
       shell: bash

--- a/.github/workflows/deploy-examples.yaml
+++ b/.github/workflows/deploy-examples.yaml
@@ -37,6 +37,7 @@ jobs:
         with:
           check-commits: false
           base-path: /lightweight-charts-react-components
+          deploy: true
 
       - name: Deploy
         uses: ./.github/actions/deploy-examples

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,6 +62,7 @@ jobs:
         with:
           check-commits: false
           base-path: /lightweight-charts-react-components
+          deploy: true
 
       - name: Create a new release
         uses: ./.github/actions/create-release

--- a/examples/.env
+++ b/examples/.env
@@ -17,7 +17,7 @@ VITE_LIGHTWEIGHT_CHARTS_VERSION="0.0.0"
 VITE_LIGHTWEIGHT_CHARTS_REACT_COMPONENTS_VERSION="0.0.0"
 
 # Date of pushing the site to the production
-VITE_SITE_PUBLISHED_TIMESTAMP="0000-00-00"
+VITE_SITE_PUBLISHED_TIMESTAMP="1996-06-30"
 
 # Link to the design system figma file
 VITE_DESIGN_SYSTEM_URL="https://www.figma.com/design/J0DKy7LoduiM2zEh5NuwyU/Free-Dark-Admin-Dashboards-(Community)?node-id=5401-1157&p=f&t=t4tZdjumrorp3xfT-0"

--- a/examples/package.json
+++ b/examples/package.json
@@ -19,10 +19,10 @@
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^6.4.9",
     "@mui/material": "^6.4.7",
+    "copy-to-clipboard": "^3.3.3",
     "lightweight-charts-react-components": "file:../lib",
     "react": "^19.1.0",
     "react-dom": "^19.0.0",
-    "wouter": "^3.6.0",
     "zustand": "^5.0.3"
   }
 }

--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -1,27 +1,73 @@
-import { Container, Link, Stack, Typography } from "@mui/material";
+import { Container, Link, Stack, Typography, keyframes, styled } from "@mui/material";
 import { LayoutGrid } from "./ui/LayoutGrid";
 import { BasicSeries } from "./samples/BasicSeries/BasicSeries";
 import { colors } from "./colors";
 import { Footer } from "./ui/Footer";
 import { CustomSeries } from "./samples/CustomSeries/CustomSeries";
 import { RangeSwitcher } from "./samples/RangeSwitcher/RangeSwitcher";
+import { Markers } from "./samples/Markers/Markers";
+
+const gradientAnimation = keyframes`
+  0%   { background-position: 50% 0; }
+  12.5% { background-position: 70% 0; }
+  25%  { background-position: 75% 0; }
+  37.5% { background-position: 70% 0; }
+  50%  { background-position: 60% 0; }
+  62.5% { background-position: 55% 0; }
+  75%  { background-position: 50% 0; }
+  87.5% { background-position: 35% 0; }
+  100% { background-position: 20% 0; }
+`;
+
+const GradientLink = styled(Link)(() => ({
+  fontWeight: "bold",
+  background: `linear-gradient(90deg, ${colors.blue} 50%, ${colors.red} 70%)`,
+  backgroundSize: "300% 300%",
+  backgroundPosition: "0 0",
+  WebkitBackgroundClip: "text",
+  WebkitTextFillColor: "transparent",
+  transition: "background-position 0.3s ease-in-out",
+  "&:hover": {
+    animation: `${gradientAnimation} 2s ease-in-out infinite`,
+  },
+}));
 
 export const App = () => {
-  const { VITE_APP_DEFAULT_TITLE, VITE_LIGHTWEIGHT_CHARTS_REPO_URL } =
-    import.meta.env;
+  const { VITE_APP_DEFAULT_TITLE, VITE_LIGHTWEIGHT_CHARTS_REPO_URL } = import.meta.env;
   return (
-    <Container>
+    <Container
+      maxWidth="xl"
+      sx={{
+        paddingInline: { xs: 2, sm: 4, lg: 4 },
+      }}
+    >
       <Stack
-        spacing={{ xs: 4, sm: 6 }}
+        sx={{
+          marginTop: 4,
+        }}
+        component="header"
+        direction="row"
+        justifyContent="flex-end"
+        useFlexGap
+        gap={4}
+      >
+        <GradientLink underline="none" href="/#">
+          Examples
+        </GradientLink>
+        <Typography color="textDisabled">Terminal</Typography>
+      </Stack>
+      <Stack
+        component="main"
+        spacing={{ xs: 4, sm: 8 }}
         useFlexGap
         sx={{
-          marginTop: { xs: 4, sm: 8 },
+          marginTop: 4,
           marginBottom: 12,
         }}
       >
         <Typography
           sx={{
-            background: `linear-gradient(45deg, ${colors.red}, ${colors.blue})`,
+            background: `linear-gradient(45deg, ${colors.red}, ${colors.blue100})`,
             WebkitBackgroundClip: "text",
             WebkitTextFillColor: "transparent",
             fontSize: { xs: "2rem", sm: "3rem", md: "5rem" },
@@ -30,7 +76,7 @@ export const App = () => {
             wordBreak: "keep-all",
             lineHeight: 1,
             userSelect: "none",
-            marginInline: { md: 4 },
+            marginInline: { sm: 6, md: 12, lg: 28 },
           }}
           component="h1"
         >
@@ -40,7 +86,7 @@ export const App = () => {
           sx={{
             textAlign: "center",
             fontSize: "1.1rem",
-            marginInline: { xs: 4, sm: 12, md: 20 },
+            marginInline: { xs: 4, sm: 12, md: 28 },
           }}
           component="p"
         >
@@ -57,20 +103,22 @@ export const App = () => {
           ) : (
             "Lightweight-charts library"
           )}
-          . It provides a simple declarative way to use the
-          Lightweight-charts library in your React application.
+          . It provides a simple declarative way to use the Lightweight-charts library in
+          your React application.
         </Typography>
         <LayoutGrid>
           <BasicSeries />
           <CustomSeries />
           <RangeSwitcher />
+          <Markers />
         </LayoutGrid>
-        <Footer
-          sx={{
-            marginTop: 6,
-          }}
-        />
       </Stack>
+      <Footer
+        sx={{
+          marginTop: 6,
+          marginBottom: { xs: 4, sm: 8, md: 12, xl: 16 },
+        }}
+      />
     </Container>
   );
 };

--- a/examples/src/colors.ts
+++ b/examples/src/colors.ts
@@ -2,13 +2,15 @@ const colors = {
   white: "#f0f0f0",
   black: "#080F25",
   red: "#ff6b6b",
-  blue: "#0E43FB",
-  darkBlue: "#101935",
-  lightBlue: "#AEB9E1",
+  blue100: "#0E43FB",
+  blue200: "#101935",
+  blue: "#AEB9E1",
   gray: "#7E89AC",
+  gray100: "#343B4F",
   cyan: "#57C3FF",
   violet: "#8951FF",
   pink: "#cb3cff",
+  green: "#28a49c",
 } as const;
 
 export { colors };

--- a/examples/src/common/chartCommonOptions.ts
+++ b/examples/src/common/chartCommonOptions.ts
@@ -8,7 +8,7 @@ export const chartCommonOptions = {
     background: {
       color: "transparent",
     },
-    textColor: colors.lightBlue,
+    textColor: colors.blue,
   },
   grid: {
     vertLines: {
@@ -20,12 +20,12 @@ export const chartCommonOptions = {
   },
   crosshair: {
     vertLine: {
-      style: 0,
-      color: colors.lightBlue,
+      style: 3,
+      color: colors.gray,
     },
     horzLine: {
-      style: 0,
-      color: colors.lightBlue,
+      style: 3,
+      color: colors.gray,
     },
   },
 } satisfies DeepPartial<ChartOptions>;

--- a/examples/src/common/generateSeriesData.ts
+++ b/examples/src/common/generateSeriesData.ts
@@ -1,0 +1,41 @@
+import { createStubArray } from "./utils";
+import dayjs from "dayjs";
+
+const generateLineData = (length: number) => {
+  const start = dayjs().subtract(length, "day");
+  let lastValue = Math.floor(Math.random() * 100);
+
+  return createStubArray(length).map((_, i) => {
+    const change = Math.floor(Math.random() * 21) - 10;
+    lastValue = Math.max(0, lastValue + change);
+
+    return {
+      time: start.add(i, "day").format("YYYY-MM-DD"),
+      value: lastValue,
+    };
+  });
+};
+
+const generateOHLCData = (length: number) => {
+  const start = dayjs().subtract(length, "day");
+  let previousClose = Math.random() * 100;
+
+  return createStubArray(length).map((_, i) => {
+    const open = previousClose;
+    const high = open + Math.random() * 10;
+    const low = open - Math.random() * 10;
+    const close = low + Math.random() * (high - low);
+
+    previousClose = close;
+
+    return {
+      time: start.add(i, "day").format("YYYY-MM-DD"),
+      open,
+      high,
+      low,
+      close,
+    };
+  });
+};
+
+export { generateLineData, generateOHLCData };

--- a/examples/src/main.tsx
+++ b/examples/src/main.tsx
@@ -2,6 +2,12 @@ import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import { CssBaseline, ThemeProvider } from "@mui/material";
 import { theme } from "./theme";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+import dayjs from "dayjs";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 const root = createRoot(document.getElementById("root") || document.body);
 

--- a/examples/src/samples.ts
+++ b/examples/src/samples.ts
@@ -1,0 +1,22 @@
+const githubSamplesLocation = "https://github.com/ukorvl/lightweight-charts-react-components/tree/main/examples/src/samples";
+
+const samplesLinks = {
+  BasicSeries: {
+    githbub: `${githubSamplesLocation}/BasicSeries`,
+    codesandbox: "",
+  },
+  CustomSeries: {
+    githbub: `${githubSamplesLocation}/CustomSeries`,
+    codesandbox: "",
+  },
+  RangeSwitcher: {
+    githbub: `${githubSamplesLocation}/RangeSwitcher`,
+    codesandbox: "",
+  },
+  Markers: {
+    github: `${githubSamplesLocation}/Markers`,
+    codesandbox: "",
+  },
+} as const;
+
+export { samplesLinks };

--- a/examples/src/samples/BasicSeries/BasicSeries.tsx
+++ b/examples/src/samples/BasicSeries/BasicSeries.tsx
@@ -33,7 +33,7 @@ const BasicSeries = () => {
         ))}
       </Tabs>
       <Chart height={400} {...chartCommonOptions} autoSize>
-        {Component && <Component data={seriesData} options={options} />}
+        {Component && <Component data={seriesData} options={options} reactive={false} />}
       </Chart>
     </ChartWidgetCard>
   );

--- a/examples/src/samples/BasicSeries/BasicSeries.tsx
+++ b/examples/src/samples/BasicSeries/BasicSeries.tsx
@@ -1,16 +1,15 @@
 import { chartCommonOptions } from "@/common/chartCommonOptions";
 import { Tab, Tabs } from "@mui/material";
 import { Chart } from "lightweight-charts-react-components";
-import {
-  basicSeriesMap,
-  useSeriesStore,
-  useTabStore,
-} from "./basicSeriesStore";
+import { basicSeriesMap, useSeriesStore, useTabStore } from "./basicSeriesStore";
 import { ChartWidgetCard } from "../../ui/ChartWidgetCard";
+import { samplesLinks } from "@/samples";
+import { typedObjectKeys } from "@/common/utils";
 
 const BasicSeries = () => {
   const { activeTab, setActiveTab } = useTabStore();
   const { seriesData, seriesComponent: Component } = useSeriesStore();
+  const options = basicSeriesMap[activeTab]?.options || {};
 
   const a11yProps = (key: string) => ({
     id: `line-series-tab-${key}`,
@@ -21,18 +20,20 @@ const BasicSeries = () => {
     <ChartWidgetCard
       title="Basic series"
       subTitle="Different series types basic usage"
+      githubLink={samplesLinks.BasicSeries.githbub}
     >
       <Tabs
         value={activeTab}
         onChange={(_, newValue) => setActiveTab(newValue)}
         aria-label="basic series tabs"
+        sx={{ marginBottom: 2 }}
       >
-        {Array.from(basicSeriesMap).map(([key]) => (
+        {typedObjectKeys(basicSeriesMap).map((key) => (
           <Tab key={key} value={key} label={key} {...a11yProps(key)} />
         ))}
       </Tabs>
       <Chart height={400} {...chartCommonOptions} autoSize>
-        {Component && <Component data={seriesData} />}
+        {Component && <Component data={seriesData} options={options} />}
       </Chart>
     </ChartWidgetCard>
   );

--- a/examples/src/samples/BasicSeries/basicSeriesStore.ts
+++ b/examples/src/samples/BasicSeries/basicSeriesStore.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { colors } from "@/colors";
 import { generateLineData, generateOHLCData } from "@/common/generateSeriesData";
 import { SeriesDataItemTypeMap } from "lightweight-charts";
@@ -19,7 +17,7 @@ type BasicSeriesType = Exclude<keyof SeriesDataItemTypeMap, "Custom">;
 
 type BasicSeriesMap<K extends BasicSeriesType> = {
   [key in K]: {
-    Component: ComponentType<any>;
+    Component: ComponentType<SeriesProps<K>>;
     options?: SeriesProps<K>["options"];
   };
 };
@@ -30,11 +28,14 @@ interface TabStore {
 }
 
 interface SeriesDataStore {
-  seriesComponent: ComponentType<any> | null;
-  seriesData: any[];
-  setSeriesData: (data: any) => void;
-  setSeriesComponent: (Component: ComponentType<any> | null) => void;
+  seriesComponent: ComponentType<SeriesProps<BasicSeriesType>> | null;
+  seriesData: SeriesDataItemTypeMap[BasicSeriesType][];
+  setSeriesData: (data: SeriesDataItemTypeMap[BasicSeriesType][]) => void;
+  setSeriesComponent: (Component: ComponentType<SeriesProps<BasicSeriesType>> | null) => void;
 }
+
+const timeSeriesData = generateLineData(50);
+const ohlcSeriesData = generateOHLCData(50);
 
 const basicSeriesMap: BasicSeriesMap<BasicSeriesType> = {
   Candlestick: {
@@ -60,61 +61,17 @@ const basicSeriesMap: BasicSeriesMap<BasicSeriesType> = {
   Baseline: {
     Component: BaselineSeries,
     options: {
-      baseValue: { type: "price", price: 50 },
+      baseValue: {
+        type: "price",
+        price: Math.floor(
+          timeSeriesData.reduce((a, b) => a + b.value, 0) / timeSeriesData.length,
+        ),
+      },
       topLineColor: colors.green,
       bottomLineColor: colors.red,
     },
   },
-};//   [
-//     "Candlestick",
-//     {
-//       Component: CandlestickSeries,
-//     },
-//   ],
-//   [
-//     "Line",
-//     {
-//       Component: LineSeries,
-//     },
-//   ],
-//   [
-//     "Bar",
-//     {
-//       Component: BarSeries,
-//     },
-//   ],
-//   [
-//     "Area",
-//     {
-//       Component: AreaSeries,
-//       options: {
-//         topLineColor: colors.blue100,
-//         bottomLineColor: colors.red,
-//         crossHairMarkerVisible: true,
-//         crossHairMarkerRadius: 5,
-//         crossHairMarkerBorderWidth: 2,
-//         crossHairMarkerBorderColor: colors.red,
-//       },
-//     },
-//   ],
-//   [
-//     "Histogram",
-//     {
-//       Component: HistogramSeries,
-//     },
-//   ],
-//   [
-//     "Baseline",
-//     {
-//       Component: BaselineSeries,
-//       options: {
-//         baseValue: { type: "price", price: 50 },
-//         topLineColor: colors.green,
-//         bottomLineColor: colors.red,
-//       },
-//     },
-//   ],
-// ]);
+};
 
 const getSeriesDataByTab = (tab: BasicSeriesType) => {
   switch (tab) {
@@ -131,9 +88,6 @@ const getSeriesDataByTab = (tab: BasicSeriesType) => {
       return [];
   }
 };
-
-const timeSeriesData = generateLineData(50);
-const ohlcSeriesData = generateOHLCData(50);
 
 const useTabStore = create<TabStore>((set) => ({
   activeTab: "Candlestick",

--- a/examples/src/samples/CustomSeries/CustomSeries.tsx
+++ b/examples/src/samples/CustomSeries/CustomSeries.tsx
@@ -5,12 +5,14 @@ import {
 } from "lightweight-charts-react-components";
 import { GroupedBarsSeries } from "./plugin";
 import { chartCommonOptions } from "@/common/chartCommonOptions";
+import { samplesLinks } from "@/samples";
 
 const CustomSeries = () => {
   return (
     <ChartWidgetCard
       title="Custom series"
       subTitle="Custom series plugin usage (grouped bars)"
+      githubLink={samplesLinks.CustomSeries.githbub}
     >
       <Chart height={400} {...chartCommonOptions} autoSize>
         <CustomSeriesComponent

--- a/examples/src/samples/Markers/Markers.tsx
+++ b/examples/src/samples/Markers/Markers.tsx
@@ -1,0 +1,48 @@
+import { ChartWidgetCard } from "@/ui/ChartWidgetCard";
+import { AreaSeries, Chart, Markers } from "lightweight-charts-react-components";
+import { chartCommonOptions } from "@/common/chartCommonOptions";
+import { samplesLinks } from "@/samples";
+import { seriesData, useMarkersStore } from "./markersStore";
+import { colors } from "@/colors";
+import { FormControlLabel, FormGroup, Switch } from "@mui/material";
+
+const MarkersSample = () => {
+  const { getMarkersData, basicMarkersVisible, setBasicMarkersVisible } =
+    useMarkersStore();
+
+  return (
+    <ChartWidgetCard
+      title="Markers"
+      subTitle="Various markers display on the chart"
+      githubLink={samplesLinks.Markers.github}
+    >
+      <FormGroup>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={basicMarkersVisible}
+              onChange={() => setBasicMarkersVisible(!basicMarkersVisible)}
+              slotProps={{ input: { "aria-label": "controlled" } }}
+            />
+          }
+          label="Basic markers"
+        />
+      </FormGroup>
+      <Chart height={400} {...chartCommonOptions} autoSize>
+        <AreaSeries
+          data={seriesData}
+          options={{
+            topColor: colors.blue100,
+            bottomColor: "transparent",
+            lineColor: colors.blue100,
+            priceLineVisible: false,
+          }}
+        >
+          <Markers reactive markers={getMarkersData()} />
+        </AreaSeries>
+      </Chart>
+    </ChartWidgetCard>
+  );
+};
+
+export { MarkersSample as Markers };

--- a/examples/src/samples/Markers/Markers.tsx
+++ b/examples/src/samples/Markers/Markers.tsx
@@ -38,7 +38,7 @@ const MarkersSample = () => {
             priceLineVisible: false,
           }}
         >
-          <Markers reactive markers={getMarkersData()} />
+          <Markers markers={getMarkersData()} />
         </AreaSeries>
       </Chart>
     </ChartWidgetCard>

--- a/examples/src/samples/Markers/markersStore.tsx
+++ b/examples/src/samples/Markers/markersStore.tsx
@@ -1,0 +1,59 @@
+import { colors } from "@/colors";
+import { generateLineData } from "@/common/generateSeriesData";
+import { SeriesMarker, Time } from "lightweight-charts";
+import { create } from "zustand";
+
+interface MarkersStore {
+  basicMarkersVisible: boolean;
+  setBasicMarkersVisible: (visible: boolean) => void;
+  getMarkersData: () => SeriesMarker<Time>[];
+}
+
+const useMarkersStore = create<MarkersStore>((set, get) => ({
+  basicMarkersVisible: true,
+  setBasicMarkersVisible: (visible) => set({ basicMarkersVisible: visible }),
+  getMarkersData: () => {
+    const { basicMarkersVisible } = get();
+    return basicMarkersVisible ? basicMarkersData : [];
+  },
+}));
+
+const seriesData = generateLineData(60);
+
+const basicMarkersData = [
+  {
+    time: seriesData[5].time,
+    color: colors.red,
+    shape: "arrowUp",
+    text: "Buy",
+    position: "aboveBar",
+    size: 2,
+  },
+  {
+    time: seriesData[25].time,
+    color: colors.green,
+    shape: "arrowDown",
+    text: "Sell",
+    position: "belowBar",
+    size: 2,
+  },
+  {
+    time: seriesData[35].time,
+    price: 140,
+    color: colors.cyan,
+    shape: "circle",
+    text: "Neutral",
+    position: "inBar",
+    size: 2,
+  },
+  {
+    time: seriesData[50].time,
+    color: colors.pink,
+    shape: "square",
+    text: "Info",
+    position: "inBar",
+    size: 2,
+  },
+] satisfies SeriesMarker<Time>[];
+
+export { useMarkersStore, seriesData };

--- a/examples/src/samples/RangeSwitcher/RangeSwitcher.tsx
+++ b/examples/src/samples/RangeSwitcher/RangeSwitcher.tsx
@@ -53,7 +53,7 @@ const RangeSwitcher = () => {
         autoSize
         onInit={(chart) => chart.timeScale().fitContent()}
       >
-        <AreaSeries reactive options={seriesCustomOptions} data={data} />
+        <AreaSeries options={seriesCustomOptions} data={data} />
       </Chart>
     </ChartWidgetCard>
   );

--- a/examples/src/samples/RangeSwitcher/RangeSwitcher.tsx
+++ b/examples/src/samples/RangeSwitcher/RangeSwitcher.tsx
@@ -10,9 +10,10 @@ import {
 import { typedObjectKeys } from "@/common/utils";
 import { AreaSeriesOptions, DeepPartial } from "lightweight-charts";
 import { colors } from "@/colors";
+import { samplesLinks } from "@/samples";
 
 const seriesCustomOptions = {
-  bottomColor: `${colors.blue}05`,
+  bottomColor: `${colors.blue100}05`,
   lineColor: colors.cyan,
   topColor: colors.cyan,
 } satisfies DeepPartial<AreaSeriesOptions>;
@@ -25,11 +26,13 @@ const RangeSwitcher = () => {
     <ChartWidgetCard
       title="Range switcher"
       subTitle="Allows user to switch between different time ranges"
+      githubLink={samplesLinks.RangeSwitcher.githbub}
     >
       <ButtonGroup
         variant="outlined"
         aria-label="Basic button group"
         color="info"
+        sx={{ marginBottom: 2 }}
       >
         {typedObjectKeys(dataRangeMap).map((key) => (
           <Button
@@ -48,6 +51,7 @@ const RangeSwitcher = () => {
         }}
         {...chartCommonOptions}
         autoSize
+        onInit={(chart) => chart.timeScale().fitContent()}
       >
         <AreaSeries reactive options={seriesCustomOptions} data={data} />
       </Chart>

--- a/examples/src/theme.ts
+++ b/examples/src/theme.ts
@@ -3,6 +3,15 @@ import { colors } from "./colors";
 
 const theme = createTheme({
   cssVariables: true,
+  components: {
+    MuiCardHeader: {
+      styleOverrides: {
+        action: {
+          margin: 0,
+        }
+      }
+    }
+  },
   palette: {
     primary: {
       main: colors.pink,
@@ -15,12 +24,14 @@ const theme = createTheme({
     },
     background: {
       default: colors.black,
-      paper: colors.darkBlue,
+      paper: colors.blue200,
     },
     text: {
       primary: colors.white,
-      secondary: colors.lightBlue,
+      secondary: colors.blue,
+      disabled: colors.gray100,
     },
+    divider: colors.gray100,
   },
   typography: {
     fontFamily: "Roboto",

--- a/examples/src/ui/ChartWidgetCard.tsx
+++ b/examples/src/ui/ChartWidgetCard.tsx
@@ -1,24 +1,78 @@
-import { Card, CardContent, CardActions, CardHeader } from "@mui/material";
+import { GitHub, TableChart } from "@mui/icons-material";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  Stack,
+  Link,
+  Tooltip,
+} from "@mui/material";
 import { FC, ReactNode } from "react";
+import { CodesandboxIcon } from "./CodesandboxIcon";
 
 type ChartWidgetCardProps = {
   title: string;
   subTitle?: string;
   children?: ReactNode;
-  actionPanel?: ReactNode;
+} & AcitionPanelProps;
+
+type AcitionPanelProps = {
+  codeSnippetLink?: string;
+  githubLink: string;
+};
+
+const ActionPanel: FC<AcitionPanelProps> = ({ codeSnippetLink, githubLink }) => {
+  return (
+    <Stack direction="row" spacing={1.5}>
+      <Tooltip title="Open the source in GitHub" placement="bottom">
+        <Link
+          href={githubLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          color="secondary"
+        >
+          <GitHub />
+        </Link>
+      </Tooltip>
+      <Tooltip title="Edit in CodeSandbox" placement="bottom">
+        <Link
+          href={codeSnippetLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          color="textDisabled"
+        >
+          <CodesandboxIcon />
+        </Link>
+      </Tooltip>
+      <Tooltip title="Open in terminal" placement="bottom">
+        <Link
+          href={codeSnippetLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          color="textDisabled"
+        >
+          <TableChart />
+        </Link>
+      </Tooltip>
+    </Stack>
+  );
 };
 
 const ChartWidgetCard: FC<ChartWidgetCardProps> = ({
   children,
   title,
   subTitle,
-  actionPanel,
+  codeSnippetLink,
+  githubLink,
 }) => {
   return (
-    <Card sx={{ minWidth: 275, borderRadius: 3 }} variant="outlined">
-      <CardHeader title={title} subheader={subTitle} />
+    <Card sx={{ minWidth: 275, borderRadius: 3 }}>
+      <CardHeader
+        title={title}
+        subheader={subTitle}
+        action={<ActionPanel codeSnippetLink={codeSnippetLink} githubLink={githubLink} />}
+      />
       <CardContent>{children}</CardContent>
-      {actionPanel && <CardActions>{actionPanel}</CardActions>}
     </Card>
   );
 };

--- a/examples/src/ui/Footer.tsx
+++ b/examples/src/ui/Footer.tsx
@@ -1,18 +1,53 @@
-import { Divider, Link, Stack, Typography } from "@mui/material";
-import { GitHub } from "@mui/icons-material";
+import { Divider, IconButton, Link, Stack, Tooltip, Typography } from "@mui/material";
+import { GitHub, ContentCopy } from "@mui/icons-material";
 import { colors } from "@/colors";
 import { styled } from "@mui/material/styles";
 import { FigmaIcon } from "./FigmaIcon";
-import { ComponentProps, FC } from "react";
+import { ComponentProps, FC, useEffect, useState } from "react";
+import dayjs from "dayjs";
+import copy from "copy-to-clipboard";
 
 type FooterProps = {
   sx?: ComponentProps<typeof Stack>["sx"];
+};
+
+type CopyIconProps = {
+  textToCopy: string;
+  ariaLabel?: string;
 };
 
 const FooterText = styled(Typography)(() => ({
   color: colors.gray,
   fontSize: "0.8rem",
 }));
+
+const CopyIcon: FC<CopyIconProps> = ({ textToCopy, ariaLabel }) => {
+  const [isCopied, setIsCopied] = useState(false);
+
+  useEffect(() => {
+    if (isCopied) {
+      const timeoutId = setTimeout(() => setIsCopied(false), 2000);
+
+      return () => clearTimeout(timeoutId);
+    }
+  }, [isCopied]);
+
+  return (
+    <Tooltip title={isCopied ? "Copied" : "Copy"} leaveDelay={250} placement="top">
+      <IconButton
+        onClick={() => {
+          copy(textToCopy);
+          setIsCopied(true);
+        }}
+        aria-label={ariaLabel}
+        color="primary"
+        sx={{ paddingBlock: 0 }}
+      >
+        <ContentCopy sx={{ fontSize: "1rem" }} />
+      </IconButton>
+    </Tooltip>
+  );
+};
 
 const Footer: FC<FooterProps> = ({ sx }) => {
   const {
@@ -29,20 +64,11 @@ const Footer: FC<FooterProps> = ({ sx }) => {
   return (
     <Stack
       component="footer"
-      direction={{ xs: "column", sm: "row" }}
-      spacing={{ xs: 2, sm: 4, md: 8 }}
+      direction={{ xs: "column", md: "row" }}
+      spacing={{ xs: 2, md: 8 }}
       justifyContent="center"
-      alignItems="flex-start"
-      divider={
-        <Divider
-          aria-hidden="true"
-          orientation="vertical"
-          flexItem
-          sx={{
-            backgroundColor: colors.gray,
-          }}
-        />
-      }
+      alignItems={{ xs: "center", md: "flex-start" }}
+      divider={<Divider aria-hidden="true" orientation="vertical" flexItem />}
       useFlexGap
       sx={sx}
     >
@@ -70,10 +96,24 @@ const Footer: FC<FooterProps> = ({ sx }) => {
         </FooterText>
       </Stack>
       <Stack useFlexGap spacing={2} alignItems="center">
-        <FooterText>{`lightweight-charts-react-components version: v${VITE_LIGHTWEIGHT_CHARTS_REACT_COMPONENTS_VERSION}`}</FooterText>
-        <FooterText>{`lightweight-charts version: v${VITE_LIGHTWEIGHT_CHARTS_VERSION}`}</FooterText>
+        <Stack useFlexGap direction="row" alignItems="center">
+          <FooterText>
+            {`Lightweight-charts-react-components version: ${VITE_LIGHTWEIGHT_CHARTS_REACT_COMPONENTS_VERSION}`}
+          </FooterText>
+          <CopyIcon
+            textToCopy={VITE_LIGHTWEIGHT_CHARTS_REACT_COMPONENTS_VERSION}
+            ariaLabel="Copy version of the Lightweight-charts-react-components"
+          />
+        </Stack>
+        <Stack useFlexGap direction="row" alignItems="center">
+          <FooterText>{`Lightweight-charts version: ${VITE_LIGHTWEIGHT_CHARTS_VERSION}`}</FooterText>
+          <CopyIcon
+            textToCopy={VITE_LIGHTWEIGHT_CHARTS_VERSION}
+            ariaLabel="Copy version of the Lightweight-charts"
+          />
+        </Stack>
         <FooterText>
-          site{" "}
+          Site{" "}
           {VITE_PUBLISH_COMMIT_URL ? (
             <Link
               underline="hover"
@@ -86,7 +126,7 @@ const Footer: FC<FooterProps> = ({ sx }) => {
           ) : (
             "published"
           )}
-          {`: ${VITE_SITE_PUBLISHED_TIMESTAMP}`}
+          {`: ${dayjs.utc(VITE_SITE_PUBLISHED_TIMESTAMP).local().format("YYYY-MM-DD")}`}
         </FooterText>
       </Stack>
       <Stack useFlexGap spacing={2}>

--- a/examples/src/ui/LayoutGrid.tsx
+++ b/examples/src/ui/LayoutGrid.tsx
@@ -7,9 +7,9 @@ type LayoutGridProps = {
 
 const LayoutGrid: FC<LayoutGridProps> = ({ children }) => {
   return (
-    <Grid container spacing={4}>
+    <Grid container spacing={{ xs: 2, sm: 4 }}>
       {Children.map(children, (child) => (
-        <Grid size={{ xs: 12, md: 12 }}>{child}</Grid>
+        <Grid size={{ xs: 12, lg: 6 }}>{child}</Grid>
       ))}
     </Grid>
   );

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2025-04-03
+### Fix
+- fix empty markers on init issue
+
 ## [0.1.0] - 2025-03-31
 ### Feat
 - migrate to lightweight-charts v5

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [0.1.1] - 2025-04-03
 ### Fix
 - fix empty markers on init issue
+### Feat
+- make series and markers reactive by default
 
 ## [0.1.0] - 2025-03-31
 ### Feat

--- a/lib/README.md
+++ b/lib/README.md
@@ -55,9 +55,11 @@
 </p>
 
 ## Description
+
 This library is a set of React components that wraps the Lightweight-charts library. It provides a simple declarative way to use the Lightweight-charts library in your React application.
 
 ## Table of Contents
+
 - [Installation](#installation)
 - [Usage](#usage)
 - [Examples](#examples)
@@ -65,17 +67,29 @@ This library is a set of React components that wraps the Lightweight-charts libr
 - [License](#license)
 
 ## Installation
+
 You can install the library via npm, pnpm or yarn:
+
 ```bash
 npm install lightweight-charts-react-components lightweight-charts
 ```
 
 Standalone version of the library is also available and includes all the necessary dependencies except react:
+
 ```html
 <head>
-  <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
-  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
-  <script src="https://unpkg.com/lightweight-charts-react-components/dist/lightweight-charts-react-components.standalone.js" crossorigin></script>
+  <script
+    src="https://unpkg.com/react@18/umd/react.production.min.js"
+    crossorigin
+  ></script>
+  <script
+    src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"
+    crossorigin
+  ></script>
+  <script
+    src="https://unpkg.com/lightweight-charts-react-components/dist/lightweight-charts-react-components.standalone.js"
+    crossorigin
+  ></script>
 </head>
 <body>
   <script>
@@ -85,13 +99,26 @@ Standalone version of the library is also available and includes all the necessa
 ```
 
 ## Usage
+
 tbd
 
 ## Examples
+
 tbd
 
 ## Contributing
-tbd
+
+We welcome contributions of all kinds! Whether it's fixing bugs, adding new features, improving examples, or suggesting ideas—your help is greatly appreciated.
+
+### How to Contribute
+1. Fork the repository and create a new branch for your changes.
+2. Make your changes following the project guidelines.
+3. Test your changes to ensure everything works as expected.
+4. Submit a pull request.
+
+For detailed contribution guidelines, please check out our [CONTRIBUTING.md](../CONTRIBUTING.md)
+Thank you for helping improve this project!
 
 ## License
+
 This project is licensed under the MIT License - see the [LICENSE](https://github.com/ukorvl/lightweight-charts-react-components/blob/main/lib/LICENSE) file for details.

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightweight-charts-react-components",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch"

--- a/lib/src/chart/types.ts
+++ b/lib/src/chart/types.ts
@@ -1,9 +1,9 @@
-import type {
-  ChartOptions as ChartNativeOptions,
-  DeepPartial,
-  IChartApi,
-  MouseEventHandler,
-  Time,
+import {
+  type ChartOptions as ChartNativeOptions,
+  type DeepPartial,
+  type IChartApi,
+  type MouseEventHandler,
+  type Time,
 } from "lightweight-charts";
 import { ReactNode } from "react";
 

--- a/lib/src/markers/useInitMarkers.ts
+++ b/lib/src/markers/useInitMarkers.ts
@@ -17,7 +17,7 @@ export const useInitMarkers = ({ reactive, markers }: MarkersProps) => {
           return null;
         }
 
-        this._markers = createSeriesMarkers(seriesApi, []);
+        this._markers = createSeriesMarkers(seriesApi, markers);
       }
 
       return this._markers;

--- a/lib/src/markers/useInitMarkers.ts
+++ b/lib/src/markers/useInitMarkers.ts
@@ -4,7 +4,7 @@ import { createSeriesMarkers } from "lightweight-charts";
 import { useSafeContext } from "@/shared/useSafeContext";
 import { SeriesContext } from "@/series/SeriesContext";
 
-export const useInitMarkers = ({ reactive, markers }: MarkersProps) => {
+export const useInitMarkers = ({ reactive = true, markers }: MarkersProps) => {
   const series = useSafeContext(SeriesContext);
 
   const markersApiRef = useRef<MarkersApiRef>({

--- a/lib/src/series/useInitSeries.ts
+++ b/lib/src/series/useInitSeries.ts
@@ -25,7 +25,7 @@ export const useInitSeries = <T extends SeriesType>({
   type,
   data,
   options = {},
-  reactive,
+  reactive = true,
   ...rest
 }: Omit<SeriesTemplateProps<T>, "children">) => {
   const chart = useSafeContext(ChartContext);

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,10 +49,10 @@
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^6.4.9",
         "@mui/material": "^6.4.7",
+        "copy-to-clipboard": "^3.3.3",
         "lightweight-charts-react-components": "file:../lib",
         "react": "^19.1.0",
         "react-dom": "^19.0.0",
-        "wouter": "^3.6.0",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -63,7 +63,7 @@
     },
     "lib": {
       "name": "lightweight-charts-react-components",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-extractor": "^7.52.1",
@@ -4140,6 +4140,14 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "node_modules/core-js": {
       "version": "3.41.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.41.0.tgz",
@@ -6817,11 +6825,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7416,14 +7419,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/regexparam": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-3.0.0.tgz",
-      "integrity": "sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/require-directory": {
@@ -8269,6 +8264,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -8521,6 +8521,8 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
       "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "optional": true,
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -8882,19 +8884,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wouter": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/wouter/-/wouter-3.6.0.tgz",
-      "integrity": "sha512-l11eR4urCc+CbY8+pV8HKFHxEqMgffss9aVB1XwiSkLDtH3cI6XpCa50cOzREzL0KwQqrwCVE5dCyeNcCgFpPg==",
-      "dependencies": {
-        "mitt": "^3.0.1",
-        "regexparam": "^3.0.0",
-        "use-sync-external-store": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
       }
     },
     "node_modules/wrap-ansi": {


### PR DESCRIPTION
## Short Summary

This diff adds Markers example to the example app and fixes minor issues through out the lib and app.

## Changes made
- Minor styling adjustments on examples page
- Make example series data look more realistic
- Add links to the source code for each code sample so it is easy to copy/paste
- Fix empty markers setting `this._markers = createSeriesMarkers(seriesApi, []);`
- Make markers and series reactive by default

## Related Issues
Fixes #23 
