### PR TITLE
chore: dependabot ignore major updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,6 +11,8 @@ updates:
       include: "scope"
     ignore:
       - dependency-name: "lightweight-charts"
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       react-packages:
         patterns:


### PR DESCRIPTION
## Short Summary

This diff adjusts dependabot config to ignore major dependencies updates.