### PR TITLE
fix: fix charts and series rendering problems

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,11 @@
 {
   "$schema": "http://json.schemastore.org/prettierrc",
-  "printWidth": 90
+  "printWidth": 90,
+  "jsxBracketSameLine": false,
+  "arrowParens": "avoid",
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "semi": true,
+  "singleQuote": false,
+  "jsxSingleQuote": false
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Thank you for your interest in contributing to **Lightweight Charts React Compon
    ```
    Note, that we use commitlint to enforce conventional commit messages.
 2. **Ensure version and changelog**:
-   If you would like to make a new release, update the version in the `package.json` file and add a new entry to the `CHANGELOG.md` file if necessary.
+   If you made a user-visible change, add a new entry to the `CHANGELOG.md` file if necessary under "Unreleased" section.
 3. **Push to Your Fork**:
    ```sh
    git push origin feature/my-new-feature
@@ -62,7 +62,8 @@ Thank you for your interest in contributing to **Lightweight Charts React Compon
    - Click "New Pull Request".
    - Select your branch and submit the PR with a clear description.
 5. **Release**:
-   When there is a need to release a new version of the library, repository maintainers should create a tag, associated with the new version and run `Release` workflow to publish the new version to npm, create a GitHub release and update the documentation.
+   When there is a need to release a new version of the library, repository maintainers should create a special commit and a tag, associated with the new version. A new version should be added to the `CHANGELOG.md` file and the version in `package.json` should be updated. The version should follow [Semantic Versioning](https://semver.org/).
+   To create a new release, run `Release` workflow in the GitHub Actions tab. This will create a new release and publish it to npm.
 ## Issues and Feature Requests
 - Use the **GitHub Issues** tab to report bugs and request features.
 

--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -52,7 +52,7 @@ export const App = () => {
         useFlexGap
         gap={4}
       >
-        <GradientLink underline="none" href="/#">
+        <GradientLink underline="none" href="#">
           Examples
         </GradientLink>
         <Typography color="textDisabled">Terminal</Typography>

--- a/examples/src/main.tsx
+++ b/examples/src/main.tsx
@@ -5,6 +5,7 @@ import { theme } from "./theme";
 import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
 import dayjs from "dayjs";
+import { StrictMode } from "react";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -12,8 +13,10 @@ dayjs.extend(timezone);
 const root = createRoot(document.getElementById("root") || document.body);
 
 root.render(
-  <ThemeProvider theme={theme}>
-    <CssBaseline />
-    <App />
-  </ThemeProvider>,
+  <StrictMode>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
+  </StrictMode>,
 );

--- a/examples/src/samples/BasicSeries/BasicSeries.tsx
+++ b/examples/src/samples/BasicSeries/BasicSeries.tsx
@@ -28,7 +28,7 @@ const BasicSeries = () => {
         aria-label="basic series tabs"
         sx={{ marginBottom: 2 }}
       >
-        {typedObjectKeys(basicSeriesMap).map((key) => (
+        {typedObjectKeys(basicSeriesMap).map(key => (
           <Tab key={key} value={key} label={key} {...a11yProps(key)} />
         ))}
       </Tabs>

--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -2,17 +2,16 @@ import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import viteCompression from "vite-plugin-compression";
 import path from "node:path";
-import htmlPlugin from "vite-plugin-html-config";
+import htmlPlugin, { type Options } from "vite-plugin-html-config";
 import { homepage, description } from "./package.json";
 
 const env = loadEnv("", process.cwd(), "");
 
-export const htmlConfig = {
+export const htmlConfig: Options = {
   title: env.VITE_APP_DEFAULT_TITLE,
   metas: [
     {
-      name: "charset",
-      content: "utf-8",
+      charset: "utf-8",
     },
     {
       name: "description",
@@ -112,7 +111,7 @@ export const htmlConfig = {
     {
       rel: "icon",
       type: "image/svg+xml",
-      href: `${env.VITE_BASE_URL}icon.svg`,
+      href: `${env.VITE_BASE_URL}/icon.svg`,
     },
     {
       rel: "preconnect",
@@ -144,7 +143,7 @@ export default defineConfig({
     },
     copyPublicDir: true,
   },
-  base: env.VITE_BASE_URL || "/",
+  base: env.VITE_BASE_URL,
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "src"),

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),  
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Fix 
+- fix rendering in strict mode
 
 ## [0.1.2] - 2025-04-05
 ### Feat

--- a/lib/README.md
+++ b/lib/README.md
@@ -57,6 +57,7 @@
 ## Description
 
 This library is a set of React components that wraps the Lightweight-charts library. It provides a simple declarative way to use the Lightweight-charts library in your React application.
+Check out the [Demo](https://ukorvl.github.io/lightweight-charts-react-components/) to see the components in action.
 
 ## Table of Contents
 

--- a/lib/src/chart/ChartComponent.tsx
+++ b/lib/src/chart/ChartComponent.tsx
@@ -1,15 +1,31 @@
 import { ChartContext } from "./ChartContext";
-import { useInitChart } from "./useInitChart";
+import { useChart } from "./useChart";
 import { ChartProps } from "./types";
 
 type ChartComponentProps = {
   container: HTMLElement;
 } & Omit<ChartProps, "className">;
 
-const ChartComponent: React.FC<ChartComponentProps> = ({ children, container, ...rest }) => {
-  const chartApiRef = useInitChart({ container, ...rest });
+const ChartComponent: React.FC<ChartComponentProps> = ({
+  children,
+  container,
+  ...rest
+}) => {
+  const {
+    chartApiRef: { current: chartApiRef },
+    initialized,
+  } = useChart({ container, ...rest });
 
-  return <ChartContext.Provider value={chartApiRef.current}>{children}</ChartContext.Provider>;
+  return (
+    <ChartContext.Provider
+      value={{
+        chartApiRef,
+        initialized,
+      }}
+    >
+      {children}
+    </ChartContext.Provider>
+  );
 };
 
 export default ChartComponent;

--- a/lib/src/chart/ChartContext.ts
+++ b/lib/src/chart/ChartContext.ts
@@ -1,5 +1,10 @@
 import { createContext } from "react";
-import { ChartApiRef } from "./types";
+import { type IChartContext } from "./types";
 
-export const ChartContext = createContext({} as ChartApiRef);
+const ChartContext = createContext<IChartContext>({
+  chartApiRef: null,
+  initialized: false,
+});
+
 ChartContext.displayName = "ChartContext";
+export { ChartContext };

--- a/lib/src/chart/types.ts
+++ b/lib/src/chart/types.ts
@@ -21,6 +21,11 @@ export type ChartProps = {
 export type ChartApiRef = {
   _chart: IChartApi | null;
   api: () => IChartApi | null;
+  init: () => IChartApi | null;
   clear: () => void;
-  destroyed: boolean;
 };
+
+export interface IChartContext {
+  chartApiRef: ChartApiRef | null;
+  initialized: boolean;
+}

--- a/lib/src/markers/Markers.tsx
+++ b/lib/src/markers/Markers.tsx
@@ -1,12 +1,12 @@
 import { ForwardedRef, forwardRef, useImperativeHandle } from "react";
 import { MarkersApiRef, MarkersProps } from "./types";
-import { useInitMarkers } from "./useInitMarkers";
+import { useMarkers } from "./useMarkers";
 
 const MarkersRenderFunction = (
   { ...rest }: MarkersProps,
-  ref: ForwardedRef<MarkersApiRef>,
+  ref: ForwardedRef<MarkersApiRef>
 ) => {
-  const markersApiRef = useInitMarkers(rest);
+  const markersApiRef = useMarkers(rest);
   useImperativeHandle(ref, () => markersApiRef.current, [markersApiRef]);
 
   return null;

--- a/lib/src/markers/types.ts
+++ b/lib/src/markers/types.ts
@@ -3,8 +3,8 @@ import { ISeriesMarkersPluginApi, SeriesMarker, Time } from "lightweight-charts"
 export type MarkersApiRef = {
   _markers: ISeriesMarkersPluginApi<Time> | null;
   api: () => ISeriesMarkersPluginApi<Time> | null;
+  init: () => ISeriesMarkersPluginApi<Time> | null;
   clear: () => void;
-  destroyed: boolean;
 };
 
 export type MarkersProps = {

--- a/lib/src/priceLine/PriceLine.tsx
+++ b/lib/src/priceLine/PriceLine.tsx
@@ -1,9 +1,12 @@
 import { ForwardedRef, forwardRef, useImperativeHandle } from "react";
 import { PriceLineApiRef, PriceLineProps } from "./types";
-import { useInitPriceLine } from "./useInitPriceLine";
+import { usePriceLine } from "./usePriceLine";
 
-const PriceLineRenderFunction = (props: PriceLineProps, ref: ForwardedRef<PriceLineApiRef>) => {
-  const priceLineApiRef = useInitPriceLine(props);
+const PriceLineRenderFunction = (
+  props: PriceLineProps,
+  ref: ForwardedRef<PriceLineApiRef>
+) => {
+  const priceLineApiRef = usePriceLine(props);
   useImperativeHandle(ref, () => priceLineApiRef.current, [priceLineApiRef]);
 
   return null;

--- a/lib/src/priceLine/types.ts
+++ b/lib/src/priceLine/types.ts
@@ -8,5 +8,6 @@ export type PriceLineProps = {
 export type PriceLineApiRef = {
   _priceLine: IPriceLine | null;
   api: () => IPriceLine | null;
+  init: () => IPriceLine | null;
   clear: () => void;
 };

--- a/lib/src/priceLine/usePriceLine.ts
+++ b/lib/src/priceLine/usePriceLine.ts
@@ -3,14 +3,18 @@ import { PriceLineApiRef, PriceLineProps } from "./types";
 import { useSafeContext } from "@/shared/useSafeContext";
 import { SeriesContext } from "@/series/SeriesContext";
 
-export const useInitPriceLine = ({ options, price }: PriceLineProps) => {
-  const series = useSafeContext(SeriesContext);
+export const usePriceLine = ({ options, price }: PriceLineProps) => {
+  const { initialized: seriesInitialized, seriesApiRef: series } =
+    useSafeContext(SeriesContext);
 
   const priceLineApiRef = useRef<PriceLineApiRef>({
     _priceLine: null,
     api() {
+      return this._priceLine;
+    },
+    init() {
       if (!this._priceLine) {
-        const seriesApi = series.api();
+        const seriesApi = series?.api();
 
         if (!seriesApi) {
           return null;
@@ -26,15 +30,19 @@ export const useInitPriceLine = ({ options, price }: PriceLineProps) => {
     },
     clear() {
       if (this._priceLine !== null) {
-        series.api()?.removePriceLine(this._priceLine);
+        series?.api()?.removePriceLine(this._priceLine);
         this._priceLine = null;
       }
     },
   });
 
   useLayoutEffect(() => {
-    priceLineApiRef.current.api();
+    if (!seriesInitialized) return;
 
+    priceLineApiRef.current.init();
+  }, [seriesInitialized]);
+
+  useLayoutEffect(() => {
     return () => {
       priceLineApiRef.current.clear();
     };

--- a/lib/src/scales/PriceScale.tsx
+++ b/lib/src/scales/PriceScale.tsx
@@ -1,9 +1,12 @@
 import { ForwardedRef, forwardRef, useImperativeHandle } from "react";
 import { PriceScaleApiRef, PriceScaleProps } from "./types";
-import { useInitPriceScale } from "./useInitPriceScale";
+import { usePriceScale } from "./usePriceScale";
 
-const PriceScaleRenderFunction = (props: PriceScaleProps, ref: ForwardedRef<PriceScaleApiRef>) => {
-  const priceScaleApiRef = useInitPriceScale(props);
+const PriceScaleRenderFunction = (
+  props: PriceScaleProps,
+  ref: ForwardedRef<PriceScaleApiRef>
+) => {
+  const priceScaleApiRef = usePriceScale(props);
   useImperativeHandle(ref, () => priceScaleApiRef.current, [priceScaleApiRef]);
 
   return null;

--- a/lib/src/scales/TimeScale.tsx
+++ b/lib/src/scales/TimeScale.tsx
@@ -1,9 +1,12 @@
 import { ForwardedRef, forwardRef, useImperativeHandle } from "react";
 import { TimeScaleApiRef, TimeScaleProps } from "./types";
-import { useInitTimeScale } from "./useInitTimeScale";
+import { useTimeScale } from "./useTimeScale";
 
-const TimeScaleRenderFunction = (props: TimeScaleProps, ref: ForwardedRef<TimeScaleApiRef>) => {
-  const timeScaleApiRef = useInitTimeScale(props);
+const TimeScaleRenderFunction = (
+  props: TimeScaleProps,
+  ref: ForwardedRef<TimeScaleApiRef>
+) => {
+  const timeScaleApiRef = useTimeScale(props);
   useImperativeHandle(ref, () => timeScaleApiRef.current, [timeScaleApiRef]);
 
   return null;

--- a/lib/src/scales/types.ts
+++ b/lib/src/scales/types.ts
@@ -17,12 +17,14 @@ export type PriceScaleOptions = DeepPartial<PriceScaleNativeOptions>;
 export type TimeScaleApiRef = {
   _timeScale: ITimeScaleApi<Time> | null;
   api: () => ITimeScaleApi<Time> | null;
+  init: () => ITimeScaleApi<Time> | null;
   clear: () => void;
 };
 
 export type PriceScaleApiRef = {
   _priceScale: IPriceScaleApi | null;
   api: () => IPriceScaleApi | null;
+  init: () => IPriceScaleApi | null;
   setId: (id: string) => void;
   clear: () => void;
 };

--- a/lib/src/series/SeriesContext.ts
+++ b/lib/src/series/SeriesContext.ts
@@ -1,5 +1,8 @@
 import { createContext } from "react";
-import { SeriesApiRef, SeriesType } from "./types";
+import { type ISeriesContext } from "./types";
 
-export const SeriesContext = createContext({} as SeriesApiRef<SeriesType>);
+export const SeriesContext = createContext<ISeriesContext>({
+  seriesApiRef: null,
+  initialized: false,
+});
 SeriesContext.displayName = "SeriesContext";

--- a/lib/src/series/SeriesTemplate.tsx
+++ b/lib/src/series/SeriesTemplate.tsx
@@ -1,4 +1,4 @@
-import { useInitSeries } from "./useInitSeries";
+import { useSeries } from "./useSeries";
 import { SeriesType, SeriesTemplateProps, SeriesApiRef } from "./types";
 import { SeriesContext } from "./SeriesContext";
 import { ForwardedRef, forwardRef, useImperativeHandle } from "react";
@@ -6,20 +6,30 @@ import { ForwardedRef, forwardRef, useImperativeHandle } from "react";
 type GenericRefComponent = (<T extends SeriesType>(
   props: SeriesTemplateProps<T> & {
     ref?: ForwardedRef<SeriesApiRef<T>>;
-  },
+  }
 ) => ReturnType<typeof SeriesTemplateRenderFunction>) & {
   displayName: string;
 };
 
 const SeriesTemplateRenderFunction = <T extends SeriesType>(
   { children, ...rest }: SeriesTemplateProps<T>,
-  ref: ForwardedRef<SeriesApiRef<T>>,
+  ref: ForwardedRef<SeriesApiRef<T>>
 ) => {
-  const seriesApi = useInitSeries(rest);
-  useImperativeHandle(ref, () => seriesApi.current, [seriesApi]);
+  const {
+    seriesApiRef: { current: seriesApiRef },
+    initialized,
+  } = useSeries(rest);
+  useImperativeHandle(ref, () => seriesApiRef, [seriesApiRef]);
 
   return (
-    <SeriesContext.Provider value={seriesApi.current}>{children}</SeriesContext.Provider>
+    <SeriesContext.Provider
+      value={{
+        seriesApiRef,
+        initialized,
+      }}
+    >
+      {children}
+    </SeriesContext.Provider>
   );
 };
 

--- a/lib/src/series/types.ts
+++ b/lib/src/series/types.ts
@@ -26,9 +26,14 @@ export type SeriesTemplateProps<T extends SeriesType> = {
 export type SeriesApiRef<T extends SeriesType> = {
   _series: ISeriesApi<T> | null;
   api: () => ISeriesApi<T> | null;
+  init: () => ISeriesApi<T> | null;
   clear: () => void;
-  destroyed: boolean;
 };
+
+export interface ISeriesContext {
+  seriesApiRef: SeriesApiRef<SeriesType> | null;
+  initialized: boolean;
+}
 
 export type SeriesOptions<T extends SeriesType> = SeriesPartialOptionsMap[T];
 

--- a/lib/src/watermark/types.ts
+++ b/lib/src/watermark/types.ts
@@ -22,15 +22,15 @@ export type WatermarkProps<T extends WatermarkType> = {
 export type WatermarkTextApiRefBase = {
   _watermark: ITextWatermarkPluginApi<Time> | null;
   api: () => ITextWatermarkPluginApi<Time> | null;
+  init: () => ITextWatermarkPluginApi<Time> | null;
   clear: () => void;
-  destroyed: boolean;
 };
 
 export type WatermarkImageApiRefBase = {
   _watermark: IImageWatermarkPluginApi<Time> | null;
   api: () => IImageWatermarkPluginApi<Time> | null;
+  init: () => IImageWatermarkPluginApi<Time> | null;
   clear: () => void;
-  destroyed: boolean;
 };
 
 export type WatermarkApiRef<T extends WatermarkType> = T extends "text"


### PR DESCRIPTION
## Short Summary
This diff fixes subtle rendering problems, that appeared in React strict mode.

## Changes made
- Fixed problems with rendering. The issue was that series `api()` calling always created a new api object even if they were supposed to be destroyed.
- Minor changes and fixes in the examples app

## Related Issues
Fixes #31 
