### PR TITLE
feat: add chart legend example

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,6 +34,7 @@ export default [
       },
     },
     rules: {
+      "no-console": "error",
       "react/react-in-jsx-scope": "off",
       "react/prop-types": "off",
       "@typescript-eslint/no-unused-expressions": "off",

--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -2,6 +2,7 @@ import { Container, Link, Stack, Typography, keyframes, styled } from "@mui/mate
 import { colors } from "./colors";
 import { BasicSeries } from "./samples/BasicSeries/BasicSeries";
 import { CustomSeries } from "./samples/CustomSeries/CustomSeries";
+import { WithLegend } from "./samples/Legend/WithLegend";
 import { Markers } from "./samples/Markers/Markers";
 import { RangeSwitcher } from "./samples/RangeSwitcher/RangeSwitcher";
 import { Watermark } from "./samples/Watermark/Watermark";
@@ -113,6 +114,7 @@ export const App = () => {
           <RangeSwitcher />
           <Markers />
           <Watermark />
+          <WithLegend />
         </LayoutGrid>
       </Stack>
       <Footer

--- a/examples/src/common/generateSeriesData.ts
+++ b/examples/src/common/generateSeriesData.ts
@@ -2,7 +2,7 @@ import dayjs from "dayjs";
 import { createStubArray } from "./utils";
 import type { CandlestickData, LineData } from "lightweight-charts";
 
-const generateLineData = (length: number): LineData[] => {
+const generateLineData = (length: number): LineData<string>[] => {
   const start = dayjs().subtract(length, "day");
   let lastValue = Math.floor(Math.random() * 100);
 
@@ -17,22 +17,28 @@ const generateLineData = (length: number): LineData[] => {
   });
 };
 
-const generateOHLCData = (length: number): CandlestickData[] => {
+const generateOHLCData = (length: number): CandlestickData<string>[] => {
   const start = dayjs().subtract(length, "day");
-  let previousClose = Math.random() * 100;
+  let previousClose = Math.max(1, Math.random() * 100);
 
   return createStubArray(length).map((_, i) => {
     const open = previousClose;
     const high = open + Math.random() * 10;
-    const low = open - Math.random() * 10;
-    const close = low + Math.random() * (high - low);
+    let low = open - Math.random() * 10;
+
+    low = Math.max(0, low);
+
+    const minimalDistance = 0.01;
+    const adjustedHigh = Math.max(high, low + minimalDistance);
+
+    const close = low + Math.random() * (adjustedHigh - low);
 
     previousClose = close;
 
     return {
       time: start.add(i, "day").format("YYYY-MM-DD"),
       open,
-      high,
+      high: adjustedHigh,
       low,
       close,
     };

--- a/examples/src/samples.ts
+++ b/examples/src/samples.ts
@@ -22,6 +22,10 @@ const samplesLinks = {
     github: `${githubSamplesLocation}/Watermark`,
     codesandbox: "",
   },
+  Legend: {
+    github: `${githubSamplesLocation}/Legend`,
+    codesandbox: "",
+  },
 } as const;
 
 export { samplesLinks };

--- a/examples/src/samples/BasicSeries/basicSeriesStore.ts
+++ b/examples/src/samples/BasicSeries/basicSeriesStore.ts
@@ -42,12 +42,24 @@ const ohlcSeriesData = generateOHLCData(50);
 const basicSeriesMap: BasicSeriesMap<BasicSeriesType> = {
   Candlestick: {
     Component: CandlestickSeries,
+    options: {
+      upColor: colors.green,
+      downColor: colors.red,
+      borderUpColor: colors.green,
+      borderDownColor: colors.red,
+      wickUpColor: colors.green,
+      wickDownColor: colors.red,
+    },
   },
   Line: {
     Component: LineSeries,
   },
   Bar: {
     Component: BarSeries,
+    options: {
+      upColor: colors.green,
+      downColor: colors.red,
+    },
   },
   Area: {
     Component: AreaSeries,

--- a/examples/src/samples/Legend/WithLegend.tsx
+++ b/examples/src/samples/Legend/WithLegend.tsx
@@ -1,0 +1,124 @@
+import {
+  Box,
+  FormControlLabel,
+  FormGroup,
+  Stack,
+  Switch,
+  Typography,
+} from "@mui/material";
+import { CrosshairMode } from "lightweight-charts";
+import { CandlestickSeries, Chart } from "lightweight-charts-react-components";
+import { colors } from "@/colors";
+import { chartCommonOptions } from "@/common/chartCommonOptions";
+import { samplesLinks } from "@/samples";
+import { ChartWidgetCard } from "@/ui/ChartWidgetCard";
+import { useLegendStore } from "./legendStore";
+import { seriesData, useLegend } from "./useLegend";
+import type { FC, ReactNode } from "react";
+
+type LegendProps = {
+  children: ReactNode;
+};
+
+const Legend: FC<LegendProps> = ({ children }) => {
+  return (
+    <Box
+      sx={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        backgroundColor: `${colors.blue200}95`,
+        padding: 2,
+        zIndex: 10,
+      }}
+    >
+      {children}
+    </Box>
+  );
+};
+
+const WithLegend = () => {
+  const { legendVisible, setLegendVisible } = useLegendStore();
+  const { ref, legendData, onCrosshairMove } = useLegend(legendVisible);
+
+  return (
+    <ChartWidgetCard
+      title="Legend"
+      subTitle="Display legend on the chart"
+      githubLink={samplesLinks.Legend.github}
+    >
+      <FormGroup sx={{ marginBottom: 2 }}>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={legendVisible}
+              onChange={() => setLegendVisible(!legendVisible)}
+              slotProps={{ input: { "aria-label": "controlled" } }}
+            />
+          }
+          label="Show legend"
+        />
+      </FormGroup>
+      <Box flexDirection="column" position="relative">
+        <Chart
+          height={400}
+          {...chartCommonOptions}
+          onCrosshairMove={onCrosshairMove}
+          crosshair={{ mode: CrosshairMode.MagnetOHLC }}
+        >
+          <CandlestickSeries
+            ref={ref}
+            data={seriesData}
+            options={{
+              upColor: colors.green,
+              downColor: colors.red,
+              borderUpColor: colors.green,
+              borderDownColor: colors.red,
+              wickUpColor: colors.green,
+              wickDownColor: colors.red,
+            }}
+          />
+        </Chart>
+        {legendData !== null && legendVisible && (
+          <Legend>
+            <Typography variant="h6" gutterBottom>
+              Your awesome chart legend
+            </Typography>
+            <Typography variant="body2">{legendData.time}</Typography>
+            <Stack direction="row" useFlexGap gap={1.2}>
+              <Typography variant="overline">
+                O:{" "}
+                <Typography color={legendData.color} variant="overline">
+                  {legendData.open}
+                </Typography>
+              </Typography>
+              <Typography variant="overline">
+                H:{" "}
+                <Typography color={legendData.color} variant="overline">
+                  {legendData.high}
+                </Typography>
+              </Typography>
+              <Typography variant="overline">
+                L:{" "}
+                <Typography color={legendData.color} variant="overline">
+                  {legendData.low}
+                </Typography>
+              </Typography>
+              <Typography variant="overline">
+                C:{" "}
+                <Typography color={legendData.color} variant="overline">
+                  {legendData.close}
+                </Typography>
+              </Typography>
+              <Typography color={legendData.color} variant="overline">
+                {legendData.change}
+              </Typography>
+            </Stack>
+          </Legend>
+        )}
+      </Box>
+    </ChartWidgetCard>
+  );
+};
+
+export { WithLegend };

--- a/examples/src/samples/Legend/legendStore.ts
+++ b/examples/src/samples/Legend/legendStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface LegendStore {
+  legendVisible: boolean;
+  setLegendVisible: (visible: boolean) => void;
+}
+
+const useLegendStore = create<LegendStore>(set => ({
+  legendVisible: true,
+  setLegendVisible: visible => set({ legendVisible: visible }),
+}));
+
+export { useLegendStore };

--- a/examples/src/samples/Legend/useLegend.ts
+++ b/examples/src/samples/Legend/useLegend.ts
@@ -1,0 +1,134 @@
+import dayjs from "dayjs";
+import { useCallback, useRef, useState } from "react";
+import { colors } from "@/colors";
+import { generateOHLCData } from "@/common/generateSeriesData";
+import type { CandlestickData } from "lightweight-charts";
+import type {
+  ISeriesApi,
+  MouseEventParams,
+  Time,
+  WhitespaceData,
+} from "lightweight-charts";
+import type { SeriesApiRef } from "lightweight-charts-react-components";
+
+type LegendData = {
+  open?: string;
+  high?: string;
+  low?: string;
+  close?: string;
+  time: string;
+  color?: string;
+  change?: string;
+};
+
+const seriesData = generateOHLCData(40);
+
+const isCandlestickData = (
+  data: CandlestickData<Time> | WhitespaceData<Time>
+): data is CandlestickData<Time> => {
+  return "close" in data && "open" in data && "high" in data && "low" in data;
+};
+
+const timeToString = (time: Time): string => {
+  if (typeof time === "number") {
+    return dayjs(time * 1000).format("YYYY-MM-DD");
+  }
+
+  if (typeof time === "object") {
+    const date = new Date(time.year, time.month - 1, time.day);
+    return dayjs(date).format("YYYY-MM-DD");
+  }
+
+  return time;
+};
+
+const mapCandlestickDataToLegendData = ({
+  open,
+  high,
+  low,
+  close,
+  time,
+}: CandlestickData): LegendData => {
+  const decreased = open > close;
+  const sign = decreased ? "-" : "+";
+  const difference = Math.abs(close - open);
+
+  return {
+    open: open.toFixed(1),
+    high: high.toFixed(1),
+    low: low.toFixed(1),
+    close: close.toFixed(1),
+    time: timeToString(time),
+    color: decreased ? colors.red : colors.green,
+    change: `${sign}${difference.toFixed(1)} (${sign}${((difference / open) * 100).toFixed(2)}%)`,
+  };
+};
+
+const getLastBarLegendData = (s: ISeriesApi<"Candlestick">): LegendData | null => {
+  const data = s.dataByIndex(Number.MAX_SAFE_INTEGER, -1);
+
+  if (!data) {
+    return null;
+  }
+
+  if (!isCandlestickData(data)) {
+    return null;
+  }
+
+  return mapCandlestickDataToLegendData(data);
+};
+
+const useLegend = (showLegend: boolean) => {
+  const ref = useRef<SeriesApiRef<"Candlestick">>(null);
+  const [legendData, setLegendData] = useState<LegendData | null>(() =>
+    mapCandlestickDataToLegendData(seriesData[seriesData.length - 1])
+  );
+
+  const onCrosshairMove = useCallback(
+    (param: MouseEventParams) => {
+      if (!showLegend) {
+        return;
+      }
+
+      if (!ref.current) {
+        return;
+      }
+
+      const seriesApi = ref.current.api();
+      if (!seriesApi) {
+        return;
+      }
+
+      if (!param) {
+        return;
+      }
+
+      if (!param.time) {
+        const lastBarData = getLastBarLegendData(seriesApi);
+        setLegendData(prev => (prev?.time !== lastBarData?.time ? lastBarData : prev));
+        return;
+      }
+
+      const data = param.seriesData.get(seriesApi) as
+        | CandlestickData<Time>
+        | WhitespaceData<Time>;
+
+      if (!isCandlestickData(data)) {
+        setLegendData(null);
+        return;
+      }
+
+      const legendData = mapCandlestickDataToLegendData(data);
+      setLegendData(prev => (prev?.time !== legendData.time ? legendData : prev));
+    },
+    [setLegendData, showLegend]
+  );
+
+  return {
+    ref,
+    legendData,
+    onCrosshairMove,
+  };
+};
+
+export { useLegend, seriesData };

--- a/examples/src/samples/RangeSwitcher/rangeSwitcherStore.tsx
+++ b/examples/src/samples/RangeSwitcher/rangeSwitcherStore.tsx
@@ -15,13 +15,6 @@ interface SeriesDataStore {
   setData: (data: SeriesDataItemTypeMap["Area"][]) => void;
 }
 
-const dataRangeMap: Record<DataRange, TimeFormatterFn<string>> = {
-  "1d": t => dayjs(t).format("YYYY-MM-DD"),
-  "1w": t => dayjs(t).format("YYYY-MM-DD"),
-  "1m": t => dayjs(t).format("YYYY-MM"),
-  "1y": t => dayjs(t).format("YYYY"),
-} as const;
-
 const getSeriesDataByRange = (
   range: DataRange,
   dataLength = 50
@@ -64,19 +57,44 @@ const getSeriesDataByRange = (
   });
 };
 
+const dataRangeMap: Record<
+  DataRange,
+  {
+    formatter: TimeFormatterFn<string>;
+    data: SeriesDataItemTypeMap["Area"][];
+  }
+> = {
+  "1d": {
+    formatter: t => dayjs(t).format("YYYY-MM-DD"),
+    data: getSeriesDataByRange("1d"),
+  },
+  "1w": {
+    formatter: t => dayjs(t).format("YYYY-MM-DD"),
+    data: getSeriesDataByRange("1w"),
+  },
+  "1m": {
+    formatter: t => dayjs(t).format("YYYY-MM"),
+    data: getSeriesDataByRange("1m"),
+  },
+  "1y": {
+    formatter: t => dayjs(t).format("YYYY"),
+    data: getSeriesDataByRange("1y"),
+  },
+} as const;
+
 const useDataRangeStore = create<RangeSwitcherStore>(set => ({
   range: "1d",
   setRange: (range: DataRange) => set({ range }),
 }));
 
 const useSeriesDataStore = create<SeriesDataStore>(set => ({
-  data: getSeriesDataByRange("1d"),
+  data: dataRangeMap["1d"].data,
   setData: data => set({ data }),
 }));
 
 useDataRangeStore.subscribe(state => {
   const { range } = state;
-  useSeriesDataStore.getState().setData(getSeriesDataByRange(range));
+  useSeriesDataStore.getState().setData(dataRangeMap[range].data);
 });
 
 export { useDataRangeStore, dataRangeMap, useSeriesDataStore };

--- a/lib/README.md
+++ b/lib/README.md
@@ -105,8 +105,8 @@ tbd
 
 ## Examples
 
-Examples app itself is a [Demo](https://ukorvl.github.io/lightweight-charts-react-components/) web application, but it contains a lot of examples of how to use the library. You can find the source code of the examples in the [samples folder](https://github.com/ukorvl/lightweight-charts-react-components/blob/main/examples/src/samples). 
-You can run and test the examples app locally by cloning the repository and running the examples app.
+The [examples](https://github.com/ukorvl/lightweight-charts-react-components/blob/main/examples/) app itself is a [Demo](https://ukorvl.github.io/lightweight-charts-react-components/) web application, but it contains a lot of examples of how to use the library. You can find the source code in the [samples folder](https://github.com/ukorvl/lightweight-charts-react-components/blob/main/examples/src/samples). 
+You can run and test the code locally by cloning the repository and running the examples app.
 
 ## Contributing
 


### PR DESCRIPTION
## Short Summary

This diff adds a new example of legend usage with a OHLC data chart.

## Changes made

- A new chart legend example is added to the examples app.
- Fixed negative values in `generateOHLC()` data function call result. Left only positive values in order to make data look more realistic.

## Related Issues

Fixes #50 
