### PR TITLE
feat: Panes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 .rslib
+lib/CHANGELOG.md

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,6 +23,9 @@ export default [
   pluginReact.configs.flat.recommended,
   pluginReactHooks.configs["recommended-latest"],
   {
+    plugins: {
+      import: pluginImport,
+    },
     settings: {
       react: {
         version: "19",
@@ -60,9 +63,17 @@ export default [
     },
   },
   {
-    plugins: {
-      import: pluginImport,
+    files: [
+      "lib/src/**/*.ts",
+      "lib/src/**/*.tsx",
+      "examples/src/**/*.ts",
+      "examples/src/**/*.tsx",
+    ],
+    rules: {
+      "import/no-default-export": "error",
     },
+  },
+  {
     rules: {
       "import/order": [
         "error",

--- a/examples/index.html
+++ b/examples/index.html
@@ -7,6 +7,11 @@
 <body>
   <div id="root"></div>
   <script type="module" src="/src/main.tsx"></script>
+  <noscript>
+    <strong>
+      We're sorry but this site doesn't work properly without JavaScript enabled. Please enable it to continue.
+    </strong>
+  </noscript>
 </body>
 
 </html>

--- a/examples/package.json
+++ b/examples/package.json
@@ -21,6 +21,7 @@
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^6.4.10",
     "@mui/material": "^6.4.7",
+    "@react-hook/resize-observer": "^2.0.2",
     "copy-to-clipboard": "^3.3.3",
     "lightweight-charts-react-components": "file:../lib",
     "react": "^19.1.0",

--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -5,8 +5,10 @@ import { CompareSeries } from "./samples/CompareSeries/CompareSeries";
 import { CustomSeries } from "./samples/CustomSeries/CustomSeries";
 import { WithLegend } from "./samples/Legend/WithLegend";
 import { Markers } from "./samples/Markers/Markers";
+import { Panes } from "./samples/Panes/Panes";
 import { RangeSwitcher } from "./samples/RangeSwitcher/RangeSwitcher";
 import { Scales } from "./samples/Scales/Scales";
+import { Tooltips } from "./samples/Tooltips/Tooltips";
 import { Watermark } from "./samples/Watermark/Watermark";
 import { Footer } from "./ui/Footer";
 import { LayoutGrid } from "./ui/LayoutGrid";
@@ -96,7 +98,7 @@ export const App = () => {
             fontSize: "1.1rem",
             marginInline: { xs: 4, sm: 12, md: 28 },
           }}
-          component="p"
+          component="h2"
         >
           This library is a set of React components that wraps the{" "}
           {VITE_LIGHTWEIGHT_CHARTS_REPO_URL ? (
@@ -114,7 +116,7 @@ export const App = () => {
           . It provides a simple declarative way to use the Lightweight-charts library in
           your React application.
         </Typography>
-        <LayoutGrid>
+        <LayoutGrid component="section" aria-label="Examples of library usage">
           <BasicSeries />
           <CustomSeries />
           <RangeSwitcher />
@@ -123,6 +125,8 @@ export const App = () => {
           <WithLegend />
           <CompareSeries />
           <Scales />
+          <Tooltips />
+          <Panes />
         </LayoutGrid>
       </Stack>
       <Footer

--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -80,7 +80,7 @@ export const App = () => {
             background: `linear-gradient(45deg, ${colors.red}, ${colors.blue100})`,
             WebkitBackgroundClip: "text",
             WebkitTextFillColor: "transparent",
-            fontSize: { xs: "2rem", sm: "3rem", md: "5rem" },
+            fontSize: { xs: "2rem", sm: "3rem", md: "4rem", lg: "5rem" },
             fontWeight: "bold",
             textAlign: "center",
             wordBreak: "keep-all",

--- a/examples/src/common/chartCommonOptions.ts
+++ b/examples/src/common/chartCommonOptions.ts
@@ -1,7 +1,9 @@
 import { colors } from "@/colors";
+import { deepMergePlainObjects } from "./utils";
 import type { ChartOptions, DeepPartial } from "lightweight-charts";
 
-export const chartCommonOptions = {
+const chartCommonOptions = {
+  autoSize: true,
   layout: {
     attributionLogo: false,
     fontFamily: "Roboto",
@@ -29,3 +31,9 @@ export const chartCommonOptions = {
     },
   },
 } satisfies DeepPartial<ChartOptions>;
+
+const withChartCommonOptions = (
+  options: DeepPartial<ChartOptions>
+): DeepPartial<ChartOptions> => deepMergePlainObjects(chartCommonOptions, options);
+
+export { chartCommonOptions, withChartCommonOptions };

--- a/examples/src/common/useSize.ts
+++ b/examples/src/common/useSize.ts
@@ -1,0 +1,20 @@
+import useResizeObserver from "@react-hook/resize-observer";
+import { useLayoutEffect, useState } from "react";
+import type { RefObject } from "react";
+
+const useSize = <T extends HTMLElement | null>(target: RefObject<T>) => {
+  const [size, setSize] = useState<DOMRectReadOnly>();
+
+  useLayoutEffect(() => {
+    if (!target.current) {
+      return;
+    }
+
+    setSize(target.current.getBoundingClientRect());
+  }, [target]);
+
+  useResizeObserver(target, entry => setSize(entry.contentRect));
+  return size;
+};
+
+export { useSize };

--- a/examples/src/common/utils.ts
+++ b/examples/src/common/utils.ts
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 const typedObjectKeys = <T extends object>(obj: T): Array<keyof T> => {
   return Object.keys(obj) as Array<keyof T>;
 };
@@ -11,4 +13,48 @@ const createStubArray = (length: number) => new Array(length).fill(0);
 const encodeInlineSvg = (inlineSvg: string) =>
   `data:image/svg+xml,${encodeURIComponent(inlineSvg)}`;
 
-export { typedObjectKeys, createStubArray, encodeInlineSvg, typedObjectEntries };
+const isPlainObject = (val: unknown): val is Record<string, unknown> => {
+  return Object.prototype.toString.call(val) === "[object Object]";
+};
+
+const deepMergePlainObjects = <
+  T extends Record<string, unknown>,
+  O extends Record<string, unknown>,
+>(
+  target: T,
+  source: O
+): T | O => {
+  if (!isPlainObject(target)) {
+    throw new TypeError(`Target must be a plain object, got ${typeof target}`);
+  }
+
+  if (!isPlainObject(source)) {
+    throw new TypeError(`Source must be a plain object, got ${typeof source}`);
+  }
+
+  const result = structuredClone(target) as Record<string, unknown>;
+  for (const key in source) {
+    if (!Object.prototype.hasOwnProperty.call(source, key)) {
+      continue;
+    }
+
+    const sourceValue = source[key];
+    const targetValue = target[key];
+
+    if (isPlainObject(sourceValue) && isPlainObject(targetValue)) {
+      result[key] = deepMergePlainObjects(targetValue, sourceValue);
+    } else {
+      result[key] = sourceValue;
+    }
+  }
+
+  return result as T | O;
+};
+
+export {
+  typedObjectKeys,
+  createStubArray,
+  encodeInlineSvg,
+  typedObjectEntries,
+  deepMergePlainObjects,
+};

--- a/examples/src/common/utils.ts
+++ b/examples/src/common/utils.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 const typedObjectKeys = <T extends object>(obj: T): Array<keyof T> => {
   return Object.keys(obj) as Array<keyof T>;
 };

--- a/examples/src/samples.ts
+++ b/examples/src/samples.ts
@@ -3,15 +3,15 @@ const githubSamplesLocation =
 
 const samplesLinks = {
   BasicSeries: {
-    githbub: `${githubSamplesLocation}/BasicSeries`,
+    github: `${githubSamplesLocation}/BasicSeries`,
     codesandbox: "",
   },
   CustomSeries: {
-    githbub: `${githubSamplesLocation}/CustomSeries`,
+    github: `${githubSamplesLocation}/CustomSeries`,
     codesandbox: "",
   },
   RangeSwitcher: {
-    githbub: `${githubSamplesLocation}/RangeSwitcher`,
+    github: `${githubSamplesLocation}/RangeSwitcher`,
     codesandbox: "",
   },
   Markers: {
@@ -36,6 +36,10 @@ const samplesLinks = {
   },
   Tooltips: {
     github: `${githubSamplesLocation}/Tooltips`,
+    codesandbox: "",
+  },
+  Panes: {
+    github: `${githubSamplesLocation}/Panes`,
     codesandbox: "",
   },
 } as const;

--- a/examples/src/samples.ts
+++ b/examples/src/samples.ts
@@ -34,6 +34,10 @@ const samplesLinks = {
     github: `${githubSamplesLocation}/Scales`,
     codesandbox: "",
   },
+  Tooltips: {
+    github: `${githubSamplesLocation}/Tooltips`,
+    codesandbox: "",
+  },
 } as const;
 
 export { samplesLinks };

--- a/examples/src/samples/BasicSeries/BasicSeries.tsx
+++ b/examples/src/samples/BasicSeries/BasicSeries.tsx
@@ -27,6 +27,9 @@ const BasicSeries = () => {
         onChange={(_, newValue) => setActiveTab(newValue)}
         aria-label="basic series tabs"
         sx={{ marginBottom: 2 }}
+        allowScrollButtonsMobile
+        variant="scrollable"
+        scrollButtons="auto"
       >
         {typedObjectKeys(basicSeriesMap).map(key => (
           <Tab key={key} value={key} label={key} {...a11yProps(key)} />

--- a/examples/src/samples/BasicSeries/BasicSeries.tsx
+++ b/examples/src/samples/BasicSeries/BasicSeries.tsx
@@ -20,7 +20,7 @@ const BasicSeries = () => {
     <ChartWidgetCard
       title="Basic series"
       subTitle="Different series types basic usage"
-      githubLink={samplesLinks.BasicSeries.githbub}
+      githubLink={samplesLinks.BasicSeries.github}
     >
       <Tabs
         value={activeTab}
@@ -35,7 +35,7 @@ const BasicSeries = () => {
           <Tab key={key} value={key} label={key} {...a11yProps(key)} />
         ))}
       </Tabs>
-      <Chart height={400} {...chartCommonOptions} autoSize>
+      <Chart options={chartCommonOptions} containerProps={{ style: { flexGrow: "1" } }}>
         {Component && <Component data={seriesData} options={options} reactive={false} />}
       </Chart>
     </ChartWidgetCard>

--- a/examples/src/samples/CompareSeries/CompareSeries.tsx
+++ b/examples/src/samples/CompareSeries/CompareSeries.tsx
@@ -23,6 +23,7 @@ const StyledChip: FC<ChipProps> = ({ label, selected, onClick, color }) => {
       label={label}
       variant={selected ? "filled" : "outlined"}
       onClick={onClick}
+      tabIndex={onClick ? 0 : -1}
       sx={{
         backgroundColor: selected ? color : "transparent",
         borderColor: color,
@@ -30,6 +31,13 @@ const StyledChip: FC<ChipProps> = ({ label, selected, onClick, color }) => {
         "&:hover": {
           backgroundColor: selected ? color : "transparent",
         },
+        ...(onClick
+          ? {
+              "&:focus": {
+                outline: `2px solid ${color}`,
+              },
+            }
+          : {}),
       }}
     />
   );
@@ -45,7 +53,7 @@ const CompareSeries = () => {
       subTitle="Compare different series and metrics on the same chart"
       githubLink={samplesLinks.CompareSeries.github}
     >
-      <ScrollableContainer sx={{ marginBottom: 2 }}>
+      <ScrollableContainer sx={{ marginBottom: 2, paddingBlock: 1 }}>
         <StyledChip label="Asset A" color={colors.blue100} selected />
         {seriesMapEntries.map(([key, { chipColor }]) => {
           return (
@@ -60,8 +68,8 @@ const CompareSeries = () => {
         })}
       </ScrollableContainer>
       <Chart
-        height={400}
-        {...chartCommonOptions}
+        options={chartCommonOptions}
+        containerProps={{ style: { flexGrow: "1" } }}
         crosshair={{ mode: CrosshairMode.Normal }}
       >
         <AreaSeries

--- a/examples/src/samples/CompareSeries/CompareSeries.tsx
+++ b/examples/src/samples/CompareSeries/CompareSeries.tsx
@@ -1,10 +1,11 @@
-import { Chip, Stack } from "@mui/material";
+import { Chip } from "@mui/material";
 import { CrosshairMode } from "lightweight-charts";
 import { AreaSeries, Chart } from "lightweight-charts-react-components";
 import { colors } from "@/colors";
 import { chartCommonOptions } from "@/common/chartCommonOptions";
 import { typedObjectEntries } from "@/common/utils";
 import { samplesLinks } from "@/samples";
+import { ScrollableContainer } from "@/ui/ScrollableContainer";
 import { mainSeriesData, seriesMap, useCompareSeriesStore } from "./compareSeriesStore";
 import { ChartWidgetCard } from "../../ui/ChartWidgetCard";
 import type { FC } from "react";
@@ -44,7 +45,7 @@ const CompareSeries = () => {
       subTitle="Compare different series and metrics on the same chart"
       githubLink={samplesLinks.CompareSeries.github}
     >
-      <Stack direction="row" useFlexGap gap={2} marginBottom={2} flexWrap="wrap">
+      <ScrollableContainer sx={{ marginBottom: 2 }}>
         <StyledChip label="Asset A" color={colors.blue100} selected />
         {seriesMapEntries.map(([key, { chipColor }]) => {
           return (
@@ -57,7 +58,7 @@ const CompareSeries = () => {
             />
           );
         })}
-      </Stack>
+      </ScrollableContainer>
       <Chart
         height={400}
         {...chartCommonOptions}

--- a/examples/src/samples/CustomSeries/CustomSeries.tsx
+++ b/examples/src/samples/CustomSeries/CustomSeries.tsx
@@ -12,9 +12,9 @@ const CustomSeries = () => {
     <ChartWidgetCard
       title="Custom series"
       subTitle="Custom series plugin usage (grouped bars)"
-      githubLink={samplesLinks.CustomSeries.githbub}
+      githubLink={samplesLinks.CustomSeries.github}
     >
-      <Chart height={400} {...chartCommonOptions} autoSize>
+      <Chart options={chartCommonOptions} containerProps={{ style: { flexGrow: "1" } }}>
         <CustomSeriesComponent
           data={[
             {

--- a/examples/src/samples/Legend/WithLegend.tsx
+++ b/examples/src/samples/Legend/WithLegend.tsx
@@ -9,7 +9,7 @@ import {
 import { CrosshairMode } from "lightweight-charts";
 import { CandlestickSeries, Chart } from "lightweight-charts-react-components";
 import { colors } from "@/colors";
-import { chartCommonOptions } from "@/common/chartCommonOptions";
+import { withChartCommonOptions } from "@/common/chartCommonOptions";
 import { samplesLinks } from "@/samples";
 import { ChartWidgetCard } from "@/ui/ChartWidgetCard";
 import { useLegendStore } from "./legendStore";
@@ -59,12 +59,13 @@ const WithLegend = () => {
           label="Show legend"
         />
       </FormGroup>
-      <Box flexDirection="column" position="relative">
+      <Box height="100%" flexDirection="column" position="relative">
         <Chart
-          height={400}
-          {...chartCommonOptions}
+          options={withChartCommonOptions({
+            crosshair: { mode: CrosshairMode.Normal },
+          })}
+          containerProps={{ style: { height: "100%" } }}
           onCrosshairMove={onCrosshairMove}
-          crosshair={{ mode: CrosshairMode.MagnetOHLC }}
         >
           <CandlestickSeries
             ref={ref}

--- a/examples/src/samples/Markers/Markers.tsx
+++ b/examples/src/samples/Markers/Markers.tsx
@@ -28,7 +28,7 @@ const MarkersSample = () => {
           label="Basic markers"
         />
       </FormGroup>
-      <Chart height={400} {...chartCommonOptions} autoSize>
+      <Chart options={chartCommonOptions} containerProps={{ style: { flexGrow: "1" } }}>
         <CandlestickSeries
           data={seriesData}
           options={{

--- a/examples/src/samples/Panes/Panes.tsx
+++ b/examples/src/samples/Panes/Panes.tsx
@@ -4,7 +4,6 @@ import {
   Chart,
   HistogramSeries,
   LineSeries,
-  Pane,
   PriceLine,
 } from "lightweight-charts-react-components";
 import { colors } from "@/colors";
@@ -56,60 +55,56 @@ const Panes = () => {
         })}
         containerProps={{ style: { flexGrow: "1" } }}
       >
-        <Pane id={0}>
-          <CandlestickSeries
-            data={ohlcData}
-            options={{
-              upColor: "transparent",
-              downColor: colors.orange100,
-              borderUpColor: colors.blue,
-              borderDownColor: colors.orange100,
-              wickUpColor: colors.blue,
-              wickDownColor: colors.orange100,
-            }}
-          />
-        </Pane>
+        <CandlestickSeries
+          data={ohlcData}
+          options={{
+            upColor: "transparent",
+            downColor: colors.orange100,
+            borderUpColor: colors.blue,
+            borderDownColor: colors.orange100,
+            wickUpColor: colors.blue,
+            wickDownColor: colors.orange100,
+          }}
+        />
         {rsiVisible && (
-          <Pane id={1} height={100}>
-            <LineSeries
-              data={rsiData}
+          <LineSeries
+            pane
+            data={rsiData}
+            options={{
+              priceLineVisible: false,
+              color: colors.blue100,
+              lineWidth: 2,
+              priceScaleId: "right",
+            }}
+          >
+            <PriceLine
+              price={70}
               options={{
-                priceLineVisible: false,
-                color: colors.blue100,
-                lineWidth: 2,
-                priceScaleId: "right",
-              }}
-            >
-              <PriceLine
-                price={70}
-                options={{
-                  color: colors.violet,
-                  lineWidth: 1,
-                  lineStyle: 3,
-                  axisLabelVisible: true,
-                }}
-              />
-              <PriceLine
-                price={30}
-                options={{
-                  color: colors.violet,
-                  lineWidth: 1,
-                  lineStyle: 3,
-                  axisLabelVisible: true,
-                }}
-              />
-            </LineSeries>
-          </Pane>
-        )}
-        {volumesVisible && (
-          <Pane id={2} height={75}>
-            <HistogramSeries
-              data={volumeData}
-              options={{
-                priceLineVisible: false,
+                color: colors.violet,
+                lineWidth: 1,
+                lineStyle: 3,
+                axisLabelVisible: true,
               }}
             />
-          </Pane>
+            <PriceLine
+              price={30}
+              options={{
+                color: colors.violet,
+                lineWidth: 1,
+                lineStyle: 3,
+                axisLabelVisible: true,
+              }}
+            />
+          </LineSeries>
+        )}
+        {volumesVisible && (
+          <HistogramSeries
+            pane
+            data={volumeData}
+            options={{
+              priceLineVisible: false,
+            }}
+          />
         )}
       </Chart>
     </ChartWidgetCard>
@@ -117,8 +112,3 @@ const Panes = () => {
 };
 
 export { Panes };
-
-//
-//enable panes autores
-// toggle visibility of rsi and volume panes
-// buttons move pane up and move pane down (including chart itself). only pane in the middle has 2 enaled buttons

--- a/examples/src/samples/Panes/Panes.tsx
+++ b/examples/src/samples/Panes/Panes.tsx
@@ -68,7 +68,7 @@ const Panes = () => {
         />
         {rsiVisible && (
           <LineSeries
-            pane
+            isPane
             data={rsiData}
             options={{
               priceLineVisible: false,
@@ -99,7 +99,7 @@ const Panes = () => {
         )}
         {volumesVisible && (
           <HistogramSeries
-            pane
+            isPane
             data={volumeData}
             options={{
               priceLineVisible: false,

--- a/examples/src/samples/Panes/Panes.tsx
+++ b/examples/src/samples/Panes/Panes.tsx
@@ -1,0 +1,124 @@
+import { Checkbox, FormControlLabel, FormGroup } from "@mui/material";
+import {
+  CandlestickSeries,
+  Chart,
+  HistogramSeries,
+  LineSeries,
+  Pane,
+  PriceLine,
+} from "lightweight-charts-react-components";
+import { colors } from "@/colors";
+import { withChartCommonOptions } from "@/common/chartCommonOptions";
+import { samplesLinks } from "@/samples";
+import { ohlcData, rsiData, usePanesControlsStore, volumeData } from "./panesStore";
+import { ChartWidgetCard } from "../../ui/ChartWidgetCard";
+
+const Panes = () => {
+  const { volumesVisible, rsiVisible, setRsiVisible, setVolumesVisible } =
+    usePanesControlsStore();
+
+  return (
+    <ChartWidgetCard
+      title="Panes"
+      subTitle="Multiple panes on the same chart"
+      githubLink={samplesLinks.Panes.github}
+    >
+      <FormGroup sx={{ marginBottom: 2, flexDirection: "row", gap: 2 }}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={rsiVisible}
+              onChange={e => setRsiVisible(e.target.checked)}
+              slotProps={{ input: { "aria-label": "controlled" } }}
+            />
+          }
+          label="Show RSI"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={volumesVisible}
+              onChange={e => setVolumesVisible(e.target.checked)}
+              slotProps={{ input: { "aria-label": "controlled" } }}
+            />
+          }
+          label="Show Volume"
+        />
+      </FormGroup>
+      <Chart
+        options={withChartCommonOptions({
+          layout: {
+            panes: {
+              enableResize: true,
+              separatorColor: colors.gray100,
+            },
+          },
+        })}
+        containerProps={{ style: { flexGrow: "1" } }}
+      >
+        <Pane id={0}>
+          <CandlestickSeries
+            data={ohlcData}
+            options={{
+              upColor: "transparent",
+              downColor: colors.orange100,
+              borderUpColor: colors.blue,
+              borderDownColor: colors.orange100,
+              wickUpColor: colors.blue,
+              wickDownColor: colors.orange100,
+            }}
+          />
+        </Pane>
+        {rsiVisible && (
+          <Pane id={1} height={100}>
+            <LineSeries
+              data={rsiData}
+              options={{
+                priceLineVisible: false,
+                color: colors.blue100,
+                lineWidth: 2,
+                priceScaleId: "right",
+              }}
+            >
+              <PriceLine
+                price={70}
+                options={{
+                  color: colors.violet,
+                  lineWidth: 1,
+                  lineStyle: 3,
+                  axisLabelVisible: true,
+                }}
+              />
+              <PriceLine
+                price={30}
+                options={{
+                  color: colors.violet,
+                  lineWidth: 1,
+                  lineStyle: 3,
+                  axisLabelVisible: true,
+                }}
+              />
+            </LineSeries>
+          </Pane>
+        )}
+        {volumesVisible && (
+          <Pane id={2} height={75}>
+            <HistogramSeries
+              data={volumeData}
+              options={{
+                priceLineVisible: false,
+              }}
+            />
+          </Pane>
+        )}
+      </Chart>
+    </ChartWidgetCard>
+  );
+};
+
+export { Panes };
+
+//
+//enable panes autores
+// toggle visibility of rsi and volume panes
+// buttons move pane up and move pane down (including chart itself). only pane in the middle has 2 enaled buttons

--- a/examples/src/samples/Panes/panesStore.ts
+++ b/examples/src/samples/Panes/panesStore.ts
@@ -1,0 +1,81 @@
+import { create } from "zustand";
+import { colors } from "@/colors";
+import { generateHistogramData, generateOHLCData } from "@/common/generateSeriesData";
+import type { CandlestickData, LineData, WhitespaceData } from "lightweight-charts";
+
+interface PanesControlsStore {
+  rsiVisible: boolean;
+  volumesVisible: boolean;
+  setRsiVisible: (visible: boolean) => void;
+  setVolumesVisible: (visible: boolean) => void;
+}
+
+const calculateRSI = (
+  ohlcData: CandlestickData<string>[],
+  period = 14
+): (LineData | WhitespaceData)[] => {
+  const closes = ohlcData.map(data => data.close);
+  const rsiData: (LineData | WhitespaceData)[] = [];
+
+  let gainSum = 0;
+  let lossSum = 0;
+
+  for (let i = 0; i < closes.length; i++) {
+    if (i === 0) {
+      rsiData.push({ time: ohlcData[i].time });
+      continue;
+    }
+
+    const change = closes[i] - closes[i - 1];
+    const gain = Math.max(change, 0);
+    const loss = Math.abs(Math.min(change, 0));
+
+    if (i < period) {
+      gainSum += gain;
+      lossSum += loss;
+      rsiData.push({ time: ohlcData[i].time });
+      continue;
+    }
+
+    if (i === period) {
+      gainSum += gain;
+      lossSum += loss;
+
+      const avgGain = gainSum / period;
+      const avgLoss = lossSum / period;
+      const rs = avgLoss === 0 ? 100 : avgGain / avgLoss;
+      const rsi = 100 - 100 / (1 + rs);
+      rsiData.push({ time: ohlcData[i].time, value: rsi });
+    } else {
+      const prevRSIData = rsiData[i - 1] as LineData;
+      const prevAvgGain = ((prevRSIData.value ?? 50) / 100) * (lossSum + gainSum);
+      const prevAvgLoss = (1 - (prevRSIData.value ?? 50) / 100) * (lossSum + gainSum);
+
+      const avgGain = (prevAvgGain * (period - 1) + gain) / period;
+      const avgLoss = (prevAvgLoss * (period - 1) + loss) / period;
+
+      const rs = avgLoss === 0 ? 100 : avgGain / avgLoss;
+      const rsi = 100 - 100 / (1 + rs);
+
+      rsiData.push({ time: ohlcData[i].time, value: rsi });
+    }
+  }
+
+  return rsiData;
+};
+
+const ohlcData = generateOHLCData(120);
+const rsiData = calculateRSI(ohlcData, 14);
+const volumeData = generateHistogramData(120, {
+  upColor: `${colors.green}90`,
+  downColor: `${colors.red}90`,
+});
+
+const usePanesControlsStore = create<PanesControlsStore>(set => ({
+  rsiVisible: true,
+  volumesVisible: true,
+  setRsiVisible: visible => set({ rsiVisible: visible }),
+  setVolumesVisible: visible => set({ volumesVisible: visible }),
+}));
+
+export { ohlcData, rsiData, volumeData, usePanesControlsStore };

--- a/examples/src/samples/RangeSwitcher/RangeSwitcher.tsx
+++ b/examples/src/samples/RangeSwitcher/RangeSwitcher.tsx
@@ -16,6 +16,7 @@ const seriesCustomOptions = {
   bottomColor: `${colors.blue100}05`,
   lineColor: colors.cyan,
   topColor: colors.cyan,
+  lineWidth: 2,
 } satisfies DeepPartial<AreaSeriesOptions>;
 
 const RangeSwitcher = () => {
@@ -26,7 +27,7 @@ const RangeSwitcher = () => {
     <ChartWidgetCard
       title="Range switcher"
       subTitle="Allows user to switch between different time ranges"
-      githubLink={samplesLinks.RangeSwitcher.githbub}
+      githubLink={samplesLinks.RangeSwitcher.github}
     >
       <ButtonGroup
         variant="outlined"
@@ -45,16 +46,14 @@ const RangeSwitcher = () => {
         ))}
       </ButtonGroup>
       <Chart
-        height={400}
+        options={chartCommonOptions}
+        containerProps={{ style: { flexGrow: "1" } }}
         localization={{
           timeFormatter: dataRangeMap[range].formatter,
         }}
         timeScale={{
           tickMarkFormatter: dataRangeMap[range].formatter,
         }}
-        {...chartCommonOptions}
-        autoSize
-        onInit={chart => chart.timeScale().fitContent()}
       >
         <AreaSeries options={seriesCustomOptions} data={data} />
       </Chart>

--- a/examples/src/samples/Scales/Scales.tsx
+++ b/examples/src/samples/Scales/Scales.tsx
@@ -1,8 +1,9 @@
-import { FormControl, FormHelperText, MenuItem, Select, Stack } from "@mui/material";
+import { FormControl, FormHelperText, MenuItem, Select } from "@mui/material";
 import { AreaSeries, Chart, PriceScale } from "lightweight-charts-react-components";
 import { colors } from "@/colors";
 import { chartCommonOptions } from "@/common/chartCommonOptions";
 import { samplesLinks } from "@/samples";
+import { ScrollableContainer } from "@/ui/ScrollableContainer";
 import {
   mainSeriesData,
   priceScalePositionSelectOptions,
@@ -64,7 +65,7 @@ const Scales = () => {
       subTitle="Customize the scales of the chart"
       githubLink={samplesLinks.Scales.github}
     >
-      <Stack useFlexGap gap={2} direction="row" marginBottom={2} flexWrap="wrap">
+      <ScrollableContainer sx={{ marginBottom: 2 }}>
         <SelectFormField
           label="Price scales"
           value={priceScalesNumber}
@@ -84,8 +85,8 @@ const Scales = () => {
           options={priceScalePositionSelectOptions}
           disabled={priceScalesNumber === 2}
         />
-      </Stack>
-      <Chart height={400} {...chartCommonOptions}>
+      </ScrollableContainer>
+      <Chart height={400} {...chartCommonOptions} autoSize>
         <AreaSeries
           data={mainSeriesData}
           options={{

--- a/examples/src/samples/Scales/Scales.tsx
+++ b/examples/src/samples/Scales/Scales.tsx
@@ -86,7 +86,7 @@ const Scales = () => {
           disabled={priceScalesNumber === 2}
         />
       </ScrollableContainer>
-      <Chart height={400} {...chartCommonOptions} autoSize>
+      <Chart options={chartCommonOptions} containerProps={{ style: { flexGrow: "1" } }}>
         <AreaSeries
           data={mainSeriesData}
           options={{

--- a/examples/src/samples/Tooltips/Tooltips.tsx
+++ b/examples/src/samples/Tooltips/Tooltips.tsx
@@ -1,0 +1,18 @@
+import { Chart } from "lightweight-charts-react-components";
+import { chartCommonOptions } from "@/common/chartCommonOptions";
+import { samplesLinks } from "@/samples";
+import { ChartWidgetCard } from "../../ui/ChartWidgetCard";
+
+const Scales = () => {
+  return (
+    <ChartWidgetCard
+      title="Tooltips"
+      subTitle="Different tooltips on the chart"
+      githubLink={samplesLinks.Scales.github}
+    >
+      <Chart height={400} {...chartCommonOptions}></Chart>
+    </ChartWidgetCard>
+  );
+};
+
+export { Scales };

--- a/examples/src/samples/Tooltips/Tooltips.tsx
+++ b/examples/src/samples/Tooltips/Tooltips.tsx
@@ -1,7 +1,7 @@
 import { Circle } from "@mui/icons-material";
 import { Box, Grow, Stack, Tab, Tabs, Typography } from "@mui/material";
 import { Chart, LineSeries } from "lightweight-charts-react-components";
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 import { colors } from "@/colors";
 import { withChartCommonOptions } from "@/common/chartCommonOptions";
 import { typedObjectKeys } from "@/common/utils";
@@ -70,14 +70,20 @@ const BasicTooltipChart = () => {
   const containerRef = useRef<HTMLDivElement>(null);
   const tooltipWidth = 120;
   const tooltipHeight = 60;
+  const basicTooltipOpts = useMemo(
+    () => ({
+      tooltipHeight,
+      tooltipWidth,
+      yOffset: 12,
+      xOffset: 12,
+    }),
+    [tooltipHeight, tooltipWidth]
+  );
   const {
     onCrosshairMove,
     tooltipData: { time, price, position, show },
     seriesRef,
-  } = useBasicTooltip(containerRef, {
-    tooltipHeight,
-    tooltipWidth,
-  });
+  } = useBasicTooltip(containerRef, basicTooltipOpts);
 
   return (
     <Chart
@@ -138,15 +144,19 @@ const MultipleSeriesTooltipChart = () => {
   const containerRef = useRef<HTMLDivElement>(null);
   const tooltipWidth = 190;
   const tooltipHeight = 150;
+  const multipleSeriesTooltipOpts = useMemo(
+    () => ({
+      tooltipHeight,
+      tooltipWidth,
+      yOffset: 12,
+      xOffset: 12,
+    }),
+    [tooltipHeight, tooltipWidth]
+  );
   const {
     onCrosshairMove,
     tooltipData: { time, data, position, show },
-  } = useMultipleSeriesTooltip(containerRef, refs, {
-    tooltipHeight,
-    tooltipWidth,
-    yOffset: 12,
-    xOffset: 12,
-  });
+  } = useMultipleSeriesTooltip(containerRef, refs, multipleSeriesTooltipOpts);
 
   return (
     <Chart

--- a/examples/src/samples/Tooltips/Tooltips.tsx
+++ b/examples/src/samples/Tooltips/Tooltips.tsx
@@ -1,18 +1,252 @@
-import { Chart } from "lightweight-charts-react-components";
-import { chartCommonOptions } from "@/common/chartCommonOptions";
+import { Circle } from "@mui/icons-material";
+import { Box, Grow, Stack, Tab, Tabs, Typography } from "@mui/material";
+import { Chart, LineSeries } from "lightweight-charts-react-components";
+import { useRef } from "react";
+import { colors } from "@/colors";
+import { withChartCommonOptions } from "@/common/chartCommonOptions";
+import { typedObjectKeys } from "@/common/utils";
 import { samplesLinks } from "@/samples";
+import { useBasicTooltip, useMultipleSeriesTooltip } from "./hooks";
+import { basicTooltipSeriesData, multipleSeriesData, useTabStore } from "./tooltipsStore";
 import { ChartWidgetCard } from "../../ui/ChartWidgetCard";
+import type { TooltipType } from "./tooltipsStore";
+import type { SxProps } from "@mui/material";
+import type { SeriesApiRef } from "lightweight-charts-react-components";
+import type { ComponentType, FC, ReactNode, RefObject } from "react";
 
-const Scales = () => {
+type TooltipProps = {
+  x: number | null;
+  y: number | null;
+  show: boolean;
+  children: ReactNode;
+  ariaLabel: string;
+  width: number;
+  height: number;
+  sx?: SxProps;
+};
+
+const Tooltip: FC<TooltipProps> = ({
+  show,
+  x,
+  y,
+  children,
+  ariaLabel,
+  width,
+  height,
+  sx,
+}) => {
+  return (
+    <Grow in={show} timeout={{ enter: 400 }}>
+      <Box
+        role="tooltip"
+        aria-live="polite"
+        aria-atomic="true"
+        aria-label={ariaLabel}
+        sx={{
+          width: `${width}px`,
+          height: `${height}px`,
+          position: "absolute",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
+          borderRadius: 1,
+          paddingBlock: 2,
+          paddingInline: 3,
+          boxShadow: 2,
+          zIndex: 10,
+          top: y,
+          left: x,
+          ...sx,
+        }}
+      >
+        {children}
+      </Box>
+    </Grow>
+  );
+};
+
+const BasicTooltipChart = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const tooltipWidth = 120;
+  const tooltipHeight = 60;
+  const {
+    onCrosshairMove,
+    tooltipData: { time, price, position, show },
+    seriesRef,
+  } = useBasicTooltip(containerRef, {
+    tooltipHeight,
+    tooltipWidth,
+  });
+
+  return (
+    <Chart
+      ref={containerRef}
+      options={withChartCommonOptions({
+        crosshair: {
+          vertLine: {
+            style: 0,
+            color: colors.blue,
+          },
+          horzLine: {
+            style: 0,
+            color: colors.blue,
+          },
+        },
+      })}
+      containerProps={{ style: { flexGrow: "1", position: "relative" } }}
+      onCrosshairMove={onCrosshairMove}
+    >
+      <LineSeries
+        ref={seriesRef}
+        data={basicTooltipSeriesData}
+        options={{
+          color: colors.orange,
+          lineWidth: 2,
+        }}
+      />
+      <Tooltip
+        show={show}
+        x={position.x}
+        y={position.y}
+        ariaLabel={`Tooltip with chart data for time ${time} is ${price}`}
+        width={tooltipWidth}
+        height={tooltipHeight}
+        sx={{
+          color: colors.white,
+          backgroundColor: colors.violet,
+        }}
+      >
+        <Typography fontSize={18} fontWeight="bold" aria-hidden>
+          {price}
+        </Typography>
+        <Typography variant="caption" aria-hidden>
+          {time}
+        </Typography>
+      </Tooltip>
+    </Chart>
+  );
+};
+
+const MultipleSeriesTooltipChart = () => {
+  const refs: Array<RefObject<SeriesApiRef<"Line"> | null>> = [
+    useRef(null),
+    useRef(null),
+    useRef(null),
+    useRef(null),
+  ];
+  const containerRef = useRef<HTMLDivElement>(null);
+  const tooltipWidth = 190;
+  const tooltipHeight = 150;
+  const {
+    onCrosshairMove,
+    tooltipData: { time, data, position, show },
+  } = useMultipleSeriesTooltip(containerRef, refs, {
+    tooltipHeight,
+    tooltipWidth,
+    yOffset: 12,
+    xOffset: 12,
+  });
+
+  return (
+    <Chart
+      ref={containerRef}
+      options={withChartCommonOptions({
+        crosshair: {
+          vertLine: {
+            style: 0,
+            color: colors.blue,
+          },
+          horzLine: {
+            visible: false,
+          },
+        },
+      })}
+      containerProps={{ style: { flexGrow: "1", position: "relative" } }}
+      onCrosshairMove={onCrosshairMove}
+    >
+      {multipleSeriesData.map(({ data, color }, index) => (
+        <LineSeries
+          key={index}
+          ref={refs[index]}
+          data={data}
+          options={{
+            color,
+            lineWidth: 2,
+            priceLineVisible: false,
+          }}
+        />
+      ))}
+      <Tooltip
+        show={show}
+        x={position.x}
+        y={position.y}
+        ariaLabel={`Tooltip with chart data for time ${time} is ${data}`}
+        width={tooltipWidth}
+        height={tooltipHeight}
+        sx={{
+          color: colors.blue200,
+          backgroundColor: colors.white,
+          alignItems: "flex-start",
+        }}
+      >
+        {multipleSeriesData.map(({ color }, index) => (
+          <Stack key={index} direction="row" gap="1ch" alignItems="center">
+            <Circle sx={{ color, fontSize: "12px" }} />
+            <Typography variant="body1" fontWeight="bold" aria-hidden>
+              {`Asset ${String.fromCharCode(65 + index)}: ${data?.get(index) ?? "-"}`}
+            </Typography>
+          </Stack>
+        ))}
+        <Typography
+          width="100%"
+          textAlign="center"
+          variant="caption"
+          aria-hidden
+          marginTop={1}
+        >
+          {time}
+        </Typography>
+      </Tooltip>
+    </Chart>
+  );
+};
+
+const tooltipMap: Record<TooltipType, ComponentType> = {
+  Basic: BasicTooltipChart,
+  "Multiple series": MultipleSeriesTooltipChart,
+};
+
+const Tooltips = () => {
+  const { activeTab, setActiveTab } = useTabStore();
+  const a11yProps = (key: string) => ({
+    id: `tooltips-tab-${key}`,
+    "aria-controls": `tooltips-tabpanel-${key}`,
+  });
+  const ChartComponent = tooltipMap[activeTab];
+
   return (
     <ChartWidgetCard
       title="Tooltips"
       subTitle="Different tooltips on the chart"
-      githubLink={samplesLinks.Scales.github}
+      githubLink={samplesLinks.Tooltips.github}
     >
-      <Chart height={400} {...chartCommonOptions}></Chart>
+      <Tabs
+        value={activeTab}
+        onChange={(_, newValue) => setActiveTab(newValue)}
+        aria-label="tooltips tabs"
+        sx={{ marginBottom: 2 }}
+        allowScrollButtonsMobile
+        variant="scrollable"
+        scrollButtons="auto"
+      >
+        {typedObjectKeys(tooltipMap).map(key => (
+          <Tab key={key} value={key} label={key} {...a11yProps(key)} />
+        ))}
+      </Tabs>
+      <ChartComponent />
     </ChartWidgetCard>
   );
 };
 
-export { Scales };
+export { Tooltips };

--- a/examples/src/samples/Tooltips/hooks.ts
+++ b/examples/src/samples/Tooltips/hooks.ts
@@ -125,7 +125,7 @@ const useBasicTooltip = (
           : prev
       );
     },
-    [containerWidth, containerHeight]
+    [containerWidth, containerHeight, options]
   );
 
   return {
@@ -203,7 +203,7 @@ const useMultipleSeriesTooltip = (
           : prev
       );
     },
-    [containerWidth, containerHeight]
+    [containerWidth, containerHeight, options]
   );
 
   return {

--- a/examples/src/samples/Tooltips/hooks.ts
+++ b/examples/src/samples/Tooltips/hooks.ts
@@ -1,0 +1,215 @@
+import { useCallback, useRef, useState } from "react";
+import { useSize } from "@/common/useSize";
+import type {
+  LineData,
+  MouseEventHandler,
+  MouseEventParams,
+  Time,
+} from "lightweight-charts";
+import type { SeriesApiRef } from "lightweight-charts-react-components";
+import type { RefObject } from "react";
+
+type BasicTooltipData = {
+  show: boolean;
+  price: string;
+  time?: string;
+  position: {
+    x: number | null;
+    y: number | null;
+  };
+};
+
+type MultipleSeriesTooltipData = {
+  show: boolean;
+  data: Map<number, string> | null;
+  time?: string;
+  position: {
+    x: number | null;
+    y: number | null;
+  };
+};
+
+type Options = {
+  tooltipWidth: number;
+  tooltipHeight: number;
+  yOffset?: number;
+  xOffset?: number;
+};
+
+const getTooltipPosition = (
+  param: MouseEventParams,
+  containerWidth: number,
+  containerHeight: number,
+  o: Options
+) => {
+  const { tooltipHeight, tooltipWidth, yOffset = 10, xOffset = 10 } = o;
+  const x = param.point!.x + xOffset;
+  const y = param.point!.y + yOffset;
+  const xOverflow = x > containerWidth - tooltipWidth;
+  const yOverflow = y > containerHeight - tooltipHeight;
+
+  return {
+    x: xOverflow ? x - tooltipWidth - xOffset * 2 : x,
+    y: yOverflow ? y - tooltipHeight - yOffset * 2 : y,
+  };
+};
+
+const getShowTooltip = (param: MouseEventParams) => {
+  return (
+    param.time !== undefined &&
+    param.point !== undefined &&
+    param.point?.x > 0 &&
+    param.point?.y > 0
+  );
+};
+
+const useBasicTooltip = (
+  containerRef: RefObject<HTMLElement | null>,
+  options: Options
+) => {
+  const seriesRef = useRef<SeriesApiRef<"Line">>(null);
+  const size = useSize(containerRef);
+  const containerWidth = size?.width;
+  const containerHeight = size?.height;
+  const emptyTooltipData: BasicTooltipData = {
+    show: false,
+    price: "-",
+    position: {
+      x: null,
+      y: null,
+    },
+  };
+  const [tooltipData, setTooltipData] = useState<BasicTooltipData>(emptyTooltipData);
+
+  const onCrosshairMove: MouseEventHandler<Time> = useCallback(
+    param => {
+      if (!seriesRef.current || !containerWidth || !containerHeight) {
+        return;
+      }
+
+      if (!getShowTooltip(param)) {
+        setTooltipData(emptyTooltipData);
+        return;
+      }
+
+      const seriesApi = seriesRef.current.api();
+
+      if (!seriesApi) {
+        setTooltipData(emptyTooltipData);
+        return;
+      }
+
+      const data = param.seriesData.get(seriesApi) as LineData | undefined;
+
+      if (!data) {
+        setTooltipData(emptyTooltipData);
+        return;
+      }
+
+      const price = data.value !== undefined ? data.value.toFixed(2) : "-";
+      const time = param.time as string;
+
+      setTooltipData(prev =>
+        prev.time !== time
+          ? {
+              show: true,
+              price,
+              time,
+              position: getTooltipPosition(
+                param,
+                containerWidth,
+                containerHeight,
+                options
+              ),
+            }
+          : prev
+      );
+    },
+    [containerWidth, containerHeight]
+  );
+
+  return {
+    onCrosshairMove,
+    tooltipData,
+    seriesRef,
+  };
+};
+
+const useMultipleSeriesTooltip = (
+  containerRef: RefObject<HTMLElement | null>,
+  seriesRefs: Array<RefObject<SeriesApiRef<"Line"> | null>>,
+  options: Options
+) => {
+  const size = useSize(containerRef);
+  const containerWidth = size?.width;
+  const containerHeight = size?.height;
+  const emptyTooltipData: MultipleSeriesTooltipData = {
+    show: false,
+    data: null,
+    position: {
+      x: null,
+      y: null,
+    },
+  };
+  const [tooltipData, setTooltipData] =
+    useState<MultipleSeriesTooltipData>(emptyTooltipData);
+
+  const onCrosshairMove: MouseEventHandler<Time> = useCallback(
+    param => {
+      if (!containerWidth || !containerHeight) {
+        return;
+      }
+
+      const showTooltip =
+        param.time !== undefined &&
+        param.point !== undefined &&
+        param.point?.x > 0 &&
+        param.point?.y > 0;
+
+      if (!showTooltip) {
+        setTooltipData(emptyTooltipData);
+        return;
+      }
+
+      const data = new Map<number, string>();
+      seriesRefs.forEach((ref, index) => {
+        const seriesApi = ref.current?.api();
+        if (seriesApi) {
+          const seriesData = param.seriesData.get(seriesApi) as LineData | undefined;
+          if (seriesData && seriesData.value !== undefined) {
+            data.set(
+              index,
+              seriesData.value !== undefined ? seriesData.value.toFixed(2) : "-"
+            );
+          }
+        }
+      });
+
+      const time = param.time as string;
+
+      setTooltipData(prev =>
+        prev.time !== time
+          ? {
+              show: true,
+              data,
+              time,
+              position: getTooltipPosition(
+                param,
+                containerWidth,
+                containerHeight,
+                options
+              ),
+            }
+          : prev
+      );
+    },
+    [containerWidth, containerHeight]
+  );
+
+  return {
+    onCrosshairMove,
+    tooltipData,
+  };
+};
+
+export { useBasicTooltip, useMultipleSeriesTooltip };

--- a/examples/src/samples/Tooltips/tooltipsStore.ts
+++ b/examples/src/samples/Tooltips/tooltipsStore.ts
@@ -1,0 +1,25 @@
+import { create } from "zustand";
+import { colors } from "@/colors";
+import { generateLineData } from "@/common/generateSeriesData";
+
+type TooltipType = "Basic" | "Multiple series";
+
+interface TabStore {
+  activeTab: TooltipType;
+  setActiveTab: (tab: TooltipType) => void;
+}
+
+const useTabStore = create<TabStore>(set => ({
+  activeTab: "Basic",
+  setActiveTab: tab => set({ activeTab: tab }),
+}));
+
+const basicTooltipSeriesData = generateLineData(100);
+const multipleSeriesData = [
+  { data: generateLineData(100), color: colors.red },
+  { data: generateLineData(100), color: colors.green },
+  { data: generateLineData(100), color: colors.orange100 },
+  { data: generateLineData(100), color: colors.pink },
+] as const;
+
+export { useTabStore, basicTooltipSeriesData, multipleSeriesData, type TooltipType };

--- a/examples/src/samples/Watermark/Watermark.tsx
+++ b/examples/src/samples/Watermark/Watermark.tsx
@@ -31,7 +31,7 @@ const Watermark = () => {
           <Tab key={key} value={key} label={key} {...a11yProps(key)} />
         ))}
       </Tabs>
-      <Chart height={400} {...chartCommonOptions} autoSize>
+      <Chart options={chartCommonOptions} containerProps={{ style: { flexGrow: "1" } }}>
         <AreaSeries
           data={seriesData}
           options={{

--- a/examples/src/theme.ts
+++ b/examples/src/theme.ts
@@ -28,6 +28,16 @@ const theme = createTheme({
           "&:hover .MuiOutlinedInput-notchedOutline": {
             borderColor: colors.gray,
           },
+          "&.Mui-disabled": {
+            color: `${colors.gray100} !important`,
+
+            "& .MuiOutlinedInput-notchedOutline": {
+              borderColor: colors.gray100,
+            },
+            "&:hover .MuiOutlinedInput-notchedOutline": {
+              borderColor: `${colors.gray100} !important`,
+            },
+          },
         },
         icon: {
           color: colors.blue,
@@ -38,6 +48,9 @@ const theme = createTheme({
       styleOverrides: {
         root: {
           color: colors.white,
+          "&.Mui-selected": {
+            backgroundColor: `${colors.pink}65`,
+          },
           "&:hover": {
             backgroundColor: `${colors.pink}15`,
           },

--- a/examples/src/ui/ChartWidgetCard.tsx
+++ b/examples/src/ui/ChartWidgetCard.tsx
@@ -59,13 +59,29 @@ const ChartWidgetCard: FC<ChartWidgetCardProps> = ({
   githubLink,
 }) => {
   return (
-    <Card sx={{ minWidth: 275, borderRadius: 3 }}>
+    <Card
+      sx={{
+        minWidth: 275,
+        borderRadius: 3,
+        height: 575,
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
       <CardHeader
         title={title}
         subheader={subTitle}
         action={<ActionPanel codeSnippetLink={codeSnippetLink} githubLink={githubLink} />}
       />
-      <CardContent>{children}</CardContent>
+      <CardContent
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          flexGrow: 1,
+        }}
+      >
+        {children}
+      </CardContent>
     </Card>
   );
 };

--- a/examples/src/ui/Footer.tsx
+++ b/examples/src/ui/Footer.tsx
@@ -20,6 +20,7 @@ type CopyIconProps = {
 const FooterText = styled(Typography)(() => ({
   color: colors.gray,
   fontSize: "0.8rem",
+  textWrap: "nowrap",
 }));
 
 const CopyIcon: FC<CopyIconProps> = ({ textToCopy, ariaLabel }) => {
@@ -66,7 +67,7 @@ const Footer: FC<FooterProps> = ({ sx }) => {
     <Stack
       component="footer"
       direction={{ xs: "column", md: "row" }}
-      spacing={{ xs: 2, md: 8 }}
+      spacing={{ xs: 2, md: 6, lg: 8 }}
       justifyContent="center"
       alignItems={{ xs: "center", md: "flex-start" }}
       divider={<Divider aria-hidden="true" orientation="vertical" flexItem />}
@@ -141,6 +142,7 @@ const Footer: FC<FooterProps> = ({ sx }) => {
             alignItems: "center",
             gap: 1,
             fontSize: "0.8rem",
+            textWrap: "nowrap",
           }}
         >
           <GitHub />
@@ -156,6 +158,7 @@ const Footer: FC<FooterProps> = ({ sx }) => {
             alignItems: "center",
             gap: 1,
             fontSize: "0.8rem",
+            textWrap: "nowrap",
           }}
         >
           <FigmaIcon />

--- a/examples/src/ui/LayoutGrid.tsx
+++ b/examples/src/ui/LayoutGrid.tsx
@@ -1,12 +1,13 @@
 import { Grid2 as Grid } from "@mui/material";
 import { Children } from "react";
-import type { FC, ReactNode } from "react";
+import type { ElementType, FC, ReactNode } from "react";
 
 type LayoutGridProps = {
   children: ReactNode;
+  component?: ElementType;
 };
 
-const LayoutGrid: FC<LayoutGridProps> = ({ children }) => {
+const LayoutGrid: FC<LayoutGridProps> = ({ children, component, ...rest }) => {
   const childrenLength = Children.count(children);
   const numberOfChildrenIsOdd = childrenLength % 2 === 1;
 
@@ -15,6 +16,8 @@ const LayoutGrid: FC<LayoutGridProps> = ({ children }) => {
       container
       spacing={{ xs: 2, sm: 4 }}
       justifyContent={numberOfChildrenIsOdd ? "center" : "stretch"}
+      component={component ?? "div"}
+      {...rest}
     >
       {Children.map(children, (child, i) => (
         <Grid

--- a/examples/src/ui/ScrollableContainer.tsx
+++ b/examples/src/ui/ScrollableContainer.tsx
@@ -1,0 +1,148 @@
+import { Stack } from "@mui/material";
+import { useLayoutEffect, useRef, useState } from "react";
+import type { ComponentProps, FC, ReactNode } from "react";
+
+type ScrollableContainerProps = {
+  children: ReactNode;
+  direction?: "row" | "column";
+  gap?: ComponentProps<typeof Stack>["spacing"];
+  sx?: ComponentProps<typeof Stack>["sx"];
+};
+
+type Mask = {
+  left: boolean;
+  right: boolean;
+  top?: boolean;
+  bottom?: boolean;
+};
+
+const leftGradientStyles = {
+  maskImage: `linear-gradient(to left, white 90%, transparent 100%)`,
+  WebkitMaskImage: `linear-gradient(to left, white 90%, transparent 100%)`,
+};
+
+const rightGradientStyles = {
+  maskImage: `linear-gradient(to right, white 90%, transparent 100%)`,
+  WebkitMaskImage: `linear-gradient(to right, white 90%, transparent 100%)`,
+};
+
+const topGradientStyles = {
+  maskImage: `linear-gradient(to top, white 90%, transparent 100%)`,
+  WebkitMaskImage: `linear-gradient(to top, white 90%, transparent 100%)`,
+};
+
+const bottomGradientStyles = {
+  maskImage: `linear-gradient(to bottom, white 90%, transparent 100%)`,
+  WebkitMaskImage: `linear-gradient(to bottom, white 90%, transparent 100%)`,
+};
+
+const leftRightGradientStyles = {
+  maskImage: `
+    linear-gradient(to right, transparent 0%, white 10%, white 90%, transparent 100%)`,
+  WebkitMaskImage: `
+    linear-gradient(to right, transparent 0%, white 10%, white 90%, transparent 100%)`,
+};
+
+const topBottomGradientStyles = {
+  maskImage: `
+    linear-gradient(to top, transparent 0%, white 10%, white 90%, transparent 100%)`,
+  WebkitMaskImage: `
+    linear-gradient(to top, transparent 0%, white 10%, white 90%, transparent 100%)`,
+};
+
+const getMaskStyles = ({ top, right, bottom, left }: Mask) => {
+  const styles = {
+    ...(left && leftGradientStyles),
+    ...(right && rightGradientStyles),
+    ...(top && topGradientStyles),
+    ...(bottom && bottomGradientStyles),
+  };
+
+  if (left && right) {
+    Object.assign(styles, leftRightGradientStyles);
+  }
+  if (top && bottom) {
+    Object.assign(styles, topBottomGradientStyles);
+  }
+
+  return styles;
+};
+
+const ScrollableContainer: FC<ScrollableContainerProps> = ({
+  children,
+  direction = "row",
+  gap = 2,
+  sx,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [mask, setMask] = useState<Mask>({
+    left: false,
+    right: false,
+    top: false,
+    bottom: false,
+  });
+
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const updateMask = () => {
+      const {
+        scrollLeft,
+        scrollWidth,
+        clientWidth,
+        scrollTop,
+        scrollHeight,
+        clientHeight,
+      } = el;
+      const left = scrollLeft > 0;
+      const right = scrollLeft + clientWidth < scrollWidth;
+      const top = scrollTop > 0;
+      const bottom = scrollTop + clientHeight < scrollHeight;
+
+      setMask({ left, right, top, bottom });
+    };
+
+    updateMask();
+
+    el.addEventListener("scroll", updateMask);
+    window.addEventListener("resize", updateMask);
+
+    return () => {
+      el.removeEventListener("scroll", updateMask);
+      window.removeEventListener("resize", updateMask);
+    };
+  }, []);
+
+  return (
+    <Stack
+      component="div"
+      direction={direction}
+      ref={containerRef}
+      sx={{
+        ...sx,
+        overflow: "auto",
+        minWidth: 0,
+        scrollbarWidth: "none",
+        "&::-webkit-scrollbar": {
+          display: "none",
+        },
+        ...getMaskStyles(mask),
+      }}
+    >
+      <Stack
+        component="div"
+        gap={gap}
+        direction={direction}
+        sx={{
+          flexShrink: 0,
+        }}
+        flexWrap="nowrap"
+      >
+        {children}
+      </Stack>
+    </Stack>
+  );
+};
+
+export { ScrollableContainer };

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Feat
+- add containerProps to Chart props
 
 ## [0.2.1] - 2025-04-08
 ### Fix

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Feat
 - add `containerProps` and `options` to Chart props
-- add paneIndex series prop
+- add `isPane` series prop
 
 ## [0.2.1] - 2025-04-08
 ### Fix

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Feat
-- add containerProps to Chart props
+- add `containerProps` and `options` to Chart props
+- add paneIndex series prop
 
 ## [0.2.1] - 2025-04-08
 ### Fix

--- a/lib/src/chart/ChartComponent.tsx
+++ b/lib/src/chart/ChartComponent.tsx
@@ -16,14 +16,14 @@ const ChartComponent: React.FC<ChartComponentProps> = ({
 }) => {
   const {
     chartApiRef: { current: chartApiRef },
-    initialized,
+    isReady,
   } = useChart({ container, onClick, onCrosshairMove, onInit, options });
 
   return (
     <ChartContext.Provider
       value={{
         chartApiRef,
-        initialized,
+        isReady,
       }}
     >
       {children}

--- a/lib/src/chart/ChartComponent.tsx
+++ b/lib/src/chart/ChartComponent.tsx
@@ -4,17 +4,20 @@ import type { ChartProps } from "./types";
 
 type ChartComponentProps = {
   container: HTMLElement;
-} & Omit<ChartProps, "className">;
+} & Omit<ChartProps, "containerProps">;
 
 const ChartComponent: React.FC<ChartComponentProps> = ({
   children,
   container,
-  ...rest
+  onClick,
+  onCrosshairMove,
+  onInit,
+  options,
 }) => {
   const {
     chartApiRef: { current: chartApiRef },
     initialized,
-  } = useChart({ container, ...rest });
+  } = useChart({ container, onClick, onCrosshairMove, onInit, options });
 
   return (
     <ChartContext.Provider
@@ -28,4 +31,4 @@ const ChartComponent: React.FC<ChartComponentProps> = ({
   );
 };
 
-export default ChartComponent;
+export { ChartComponent };

--- a/lib/src/chart/ChartContext.ts
+++ b/lib/src/chart/ChartContext.ts
@@ -1,10 +1,7 @@
 import { createContext } from "react";
 import { type IChartContext } from "./types";
 
-const ChartContext = createContext<IChartContext>({
-  chartApiRef: null,
-  initialized: false,
-});
+const ChartContext = createContext<IChartContext | null>(null);
 
 ChartContext.displayName = "ChartContext";
 export { ChartContext };

--- a/lib/src/chart/ChartWrapper.tsx
+++ b/lib/src/chart/ChartWrapper.tsx
@@ -1,10 +1,10 @@
 import { forwardRef, useCallback, useState } from "react";
-import ChartComponent from "./ChartComponent";
+import { ChartComponent } from "./ChartComponent";
 import type { ChartProps } from "./types";
 import type { ForwardRefRenderFunction } from "react";
 
 const ChartRenderFunction: ForwardRefRenderFunction<HTMLDivElement, ChartProps> = (
-  { children, className, ...rest },
+  { children, containerProps, ...rest },
   ref
 ) => {
   const [container, setContainer] = useState<HTMLDivElement>();
@@ -24,7 +24,7 @@ const ChartRenderFunction: ForwardRefRenderFunction<HTMLDivElement, ChartProps> 
   );
 
   return (
-    <div ref={containerRef} className={className}>
+    <div ref={containerRef} {...containerProps}>
       {!!container && (
         <ChartComponent container={container} {...rest}>
           {children}
@@ -36,4 +36,4 @@ const ChartRenderFunction: ForwardRefRenderFunction<HTMLDivElement, ChartProps> 
 
 const ChartWrapper = forwardRef(ChartRenderFunction);
 ChartWrapper.displayName = "ChartWrapper";
-export default ChartWrapper;
+export { ChartWrapper };

--- a/lib/src/chart/index.ts
+++ b/lib/src/chart/index.ts
@@ -1,2 +1,2 @@
-export { default as Chart } from "./ChartWrapper";
-export type { ChartApiRef, ChartProps } from "./types";
+export { ChartWrapper as Chart } from "./ChartWrapper";
+export type { ChartApiRef, ChartProps, ChartCustomOptions } from "./types";

--- a/lib/src/chart/types.ts
+++ b/lib/src/chart/types.ts
@@ -5,18 +5,19 @@ import {
   type MouseEventHandler,
   type Time,
 } from "lightweight-charts";
-import type { ReactNode } from "react";
+import type { JSX, ReactNode } from "react";
 
-export type ChartOptions = {
+export type ChartCustomOptions = {
   onClick?: MouseEventHandler<Time>;
   onCrosshairMove?: MouseEventHandler<Time>;
   onInit?: (chart: IChartApi) => void;
-} & DeepPartial<ChartNativeOptions>;
+  options?: DeepPartial<ChartNativeOptions>;
+};
 
 export type ChartProps = {
   children?: ReactNode;
-  className?: string;
-} & ChartOptions;
+  containerProps?: JSX.IntrinsicElements["div"];
+} & ChartCustomOptions;
 
 export type ChartApiRef = {
   _chart: IChartApi | null;

--- a/lib/src/chart/types.ts
+++ b/lib/src/chart/types.ts
@@ -28,5 +28,5 @@ export type ChartApiRef = {
 
 export interface IChartContext {
   chartApiRef: ChartApiRef | null;
-  initialized: boolean;
+  isReady: boolean;
 }

--- a/lib/src/chart/useChart.ts
+++ b/lib/src/chart/useChart.ts
@@ -1,14 +1,16 @@
 import { createChart } from "lightweight-charts";
 import { useLayoutEffect, useRef, useState } from "react";
-import type { ChartApiRef, ChartOptions } from "./types";
+import type { ChartApiRef, ChartCustomOptions } from "./types";
 
 export const useChart = ({
   container,
-  ...rest
+  onClick,
+  onCrosshairMove,
+  onInit,
+  options = {},
 }: {
   container: HTMLElement;
-} & ChartOptions) => {
-  const { onClick, onCrosshairMove, onInit, ...restOptions } = rest;
+} & ChartCustomOptions) => {
   const [initialized, setInitialized] = useState(false);
 
   const chartApiRef = useRef<ChartApiRef>({
@@ -18,7 +20,7 @@ export const useChart = ({
     },
     init() {
       if (this._chart === null) {
-        this._chart = createChart(container, restOptions);
+        this._chart = createChart(container, options);
 
         if (onInit) {
           onInit(this._chart);
@@ -79,8 +81,8 @@ export const useChart = ({
   useLayoutEffect(() => {
     if (!container) return;
 
-    chartApiRef.current.api()?.applyOptions(restOptions);
-  }, [restOptions]);
+    chartApiRef.current.api()?.applyOptions(options);
+  }, [options]);
 
   return { chartApiRef, initialized };
 };

--- a/lib/src/chart/useChart.ts
+++ b/lib/src/chart/useChart.ts
@@ -11,7 +11,7 @@ export const useChart = ({
 }: {
   container: HTMLElement;
 } & ChartCustomOptions) => {
-  const [initialized, setInitialized] = useState(false);
+  const [isReady, setIsReady] = useState(false);
 
   const chartApiRef = useRef<ChartApiRef>({
     _chart: null,
@@ -27,15 +27,15 @@ export const useChart = ({
         }
       }
 
-      if (!initialized) {
-        setInitialized(true);
+      if (!isReady) {
+        setIsReady(true);
       }
 
       return this._chart;
     },
     clear() {
       if (this._chart !== null) {
-        setInitialized(false);
+        setIsReady(false);
         this._chart.remove();
         this._chart = null;
       }
@@ -84,5 +84,5 @@ export const useChart = ({
     chartApiRef.current.api()?.applyOptions(options);
   }, [options]);
 
-  return { chartApiRef, initialized };
+  return { chartApiRef, isReady };
 };

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -4,3 +4,4 @@ export * from "./series";
 export * from "./priceLine";
 export * from "./markers";
 export * from "./watermark";
+export * from "./pane";

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -4,4 +4,3 @@ export * from "./series";
 export * from "./priceLine";
 export * from "./markers";
 export * from "./watermark";
-export * from "./pane";

--- a/lib/src/markers/Markers.tsx
+++ b/lib/src/markers/Markers.tsx
@@ -15,4 +15,4 @@ const MarkersRenderFunction = (
 
 const Markers = forwardRef(MarkersRenderFunction);
 Markers.displayName = "Markers";
-export default Markers;
+export { Markers };

--- a/lib/src/markers/index.ts
+++ b/lib/src/markers/index.ts
@@ -1,2 +1,2 @@
-export { default as Markers } from "./Markers";
+export { Markers } from "./Markers";
 export type { MarkersProps, MarkersApiRef } from "./types";

--- a/lib/src/markers/useMarkers.ts
+++ b/lib/src/markers/useMarkers.ts
@@ -5,8 +5,7 @@ import { useSafeContext } from "@/shared/useSafeContext";
 import type { MarkersApiRef, MarkersProps } from "./types";
 
 export const useMarkers = ({ reactive = true, markers }: MarkersProps) => {
-  const { initialized: seriesInitialized, seriesApiRef: series } =
-    useSafeContext(SeriesContext);
+  const { isReady: seriesIsReady, seriesApiRef: series } = useSafeContext(SeriesContext);
 
   const markersApiRef = useRef<MarkersApiRef>({
     _markers: null,
@@ -35,10 +34,10 @@ export const useMarkers = ({ reactive = true, markers }: MarkersProps) => {
   });
 
   useLayoutEffect(() => {
-    if (!seriesInitialized) return;
+    if (!seriesIsReady) return;
 
     markersApiRef.current.init();
-  }, [seriesInitialized]);
+  }, [seriesIsReady]);
 
   useLayoutEffect(() => {
     return () => {

--- a/lib/src/pane/Pane.tsx
+++ b/lib/src/pane/Pane.tsx
@@ -1,25 +1,24 @@
-import { forwardRef, useImperativeHandle } from "react";
+import { forwardRef, useImperativeHandle, useState } from "react";
 import { PaneContext } from "./PaneContext";
 import { usePane } from "./usePane";
 import type { PaneProps, PaneApiRef } from "./types";
 import type { ForwardedRef } from "react";
 
-const PaneRenderFunction = (
-  { children, id, height }: PaneProps,
-  ref: ForwardedRef<PaneApiRef>
-) => {
+const PaneRenderFunction = ({ children }: PaneProps, ref: ForwardedRef<PaneApiRef>) => {
+  const [paneIndex, setPaneIndex] = useState<number | null>(null);
   const {
     paneApiRef: { current: paneApiRef },
-    initialized,
-  } = usePane({ id, height });
+    isReady,
+  } = usePane({ paneIndex });
   useImperativeHandle(ref, () => paneApiRef, [paneApiRef]);
 
   return (
     <PaneContext.Provider
       value={{
         paneApiRef,
-        initialized,
-        paneId: id,
+        isReady,
+        paneIndex,
+        setPaneIndex,
       }}
     >
       {children}

--- a/lib/src/pane/Pane.tsx
+++ b/lib/src/pane/Pane.tsx
@@ -1,0 +1,32 @@
+import { forwardRef, useImperativeHandle } from "react";
+import { PaneContext } from "./PaneContext";
+import { usePane } from "./usePane";
+import type { PaneProps, PaneApiRef } from "./types";
+import type { ForwardedRef } from "react";
+
+const PaneRenderFunction = (
+  { children, id, height }: PaneProps,
+  ref: ForwardedRef<PaneApiRef>
+) => {
+  const {
+    paneApiRef: { current: paneApiRef },
+    initialized,
+  } = usePane({ id, height });
+  useImperativeHandle(ref, () => paneApiRef, [paneApiRef]);
+
+  return (
+    <PaneContext.Provider
+      value={{
+        paneApiRef,
+        initialized,
+        paneId: id,
+      }}
+    >
+      {children}
+    </PaneContext.Provider>
+  );
+};
+
+const Pane = forwardRef(PaneRenderFunction);
+Pane.displayName = "Pane";
+export { Pane };

--- a/lib/src/pane/PaneContext.ts
+++ b/lib/src/pane/PaneContext.ts
@@ -1,9 +1,7 @@
 import { createContext } from "react";
 import { type IPaneContext } from "./types";
 
-const PaneContext = createContext<IPaneContext | null>({
-  initialized: false,
-});
+const PaneContext = createContext<IPaneContext | null>(null);
 
 PaneContext.displayName = "PaneContext";
 export { PaneContext };

--- a/lib/src/pane/PaneContext.ts
+++ b/lib/src/pane/PaneContext.ts
@@ -1,0 +1,9 @@
+import { createContext } from "react";
+import { type IPaneContext } from "./types";
+
+const PaneContext = createContext<IPaneContext | null>({
+  initialized: false,
+});
+
+PaneContext.displayName = "PaneContext";
+export { PaneContext };

--- a/lib/src/pane/index.ts
+++ b/lib/src/pane/index.ts
@@ -1,2 +1,6 @@
-export type { PaneApiRef, PaneProps } from "./types";
+export * from "./types";
 export { Pane } from "./Pane";
+
+// TODO: enable panes height prop
+// TODO: buttons move pane up and move pane down (including chart itself). only pane in the middle has 2 enaled buttons
+// TODO: panes order property

--- a/lib/src/pane/index.ts
+++ b/lib/src/pane/index.ts
@@ -1,0 +1,2 @@
+export type { PaneApiRef, PaneProps } from "./types";
+export { Pane } from "./Pane";

--- a/lib/src/pane/panesCount.ts
+++ b/lib/src/pane/panesCount.ts
@@ -1,0 +1,15 @@
+let panesCount = 0;
+
+const incrementPaneCount = () => {
+  panesCount += 1;
+  return panesCount;
+};
+
+const decrementPaneCount = () => {
+  if (panesCount !== 0) {
+    panesCount -= 1;
+  }
+  return panesCount;
+};
+
+export { panesCount, incrementPaneCount, decrementPaneCount };

--- a/lib/src/pane/types.ts
+++ b/lib/src/pane/types.ts
@@ -1,0 +1,21 @@
+import type { IPaneApi, Time } from "lightweight-charts";
+import type { ReactNode } from "react";
+
+export type PaneProps = {
+  id: number;
+  children?: ReactNode;
+  height?: number;
+};
+
+export type PaneApiRef = {
+  _pane: IPaneApi<Time> | null;
+  api: () => IPaneApi<Time> | null;
+  init: () => IPaneApi<Time> | null;
+  clear: () => void;
+};
+
+export interface IPaneContext {
+  paneApiRef?: PaneApiRef;
+  paneId?: number;
+  initialized: boolean;
+}

--- a/lib/src/pane/types.ts
+++ b/lib/src/pane/types.ts
@@ -2,20 +2,21 @@ import type { IPaneApi, Time } from "lightweight-charts";
 import type { ReactNode } from "react";
 
 export type PaneProps = {
-  id: number;
   children?: ReactNode;
-  height?: number;
 };
 
 export type PaneApiRef = {
   _pane: IPaneApi<Time> | null;
   api: () => IPaneApi<Time> | null;
-  init: () => IPaneApi<Time> | null;
+  init: (i: number) => IPaneApi<Time> | null;
   clear: () => void;
 };
 
 export interface IPaneContext {
   paneApiRef?: PaneApiRef;
-  paneId?: number;
-  initialized: boolean;
+  paneIndex: number | null;
+  setPaneIndex?: (paneIndex: number) => void;
+  isReady: boolean;
 }
+
+export type PanesMap = Map<number, number>;

--- a/lib/src/pane/usePane.ts
+++ b/lib/src/pane/usePane.ts
@@ -1,0 +1,68 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import { ChartContext } from "@/chart/ChartContext";
+import { useSafeContext } from "@/shared/useSafeContext";
+import type { PaneApiRef, PaneProps } from "./types";
+
+export const usePane = ({ id, height }: Omit<PaneProps, "children">) => {
+  const { initialized: chartInitialized, chartApiRef: chart } =
+    useSafeContext(ChartContext);
+  const [initialized, setInitialized] = useState(false);
+
+  const paneApiRef = useRef<PaneApiRef>({
+    _pane: null,
+    api() {
+      return this._pane;
+    },
+    init() {
+      setInitialized(true);
+      const panes = chart?.api()?.panes();
+
+      if (!panes) return null;
+
+      this._pane = panes[id];
+
+      if (height) {
+        this._pane.setHeight(height);
+      }
+
+      return this._pane;
+    },
+    clear() {
+      if (this._pane !== null) {
+        chart?.api()?.removePane(id);
+        setInitialized(false);
+        this._pane = null;
+      }
+    },
+  });
+
+  useLayoutEffect(() => {
+    if (!chartInitialized) return;
+
+    paneApiRef.current.init();
+  }, [chartInitialized]);
+
+  useLayoutEffect(() => {
+    return () => {
+      paneApiRef.current.clear();
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!chart) return;
+
+    if (id) {
+      paneApiRef.current.api()?.moveTo(id);
+    }
+  }, [id]);
+
+  useLayoutEffect(() => {
+    if (!chart) return;
+
+    if (height) {
+      paneApiRef.current.api()?.setHeight(height);
+    }
+  }, [height]);
+
+  return { paneApiRef, initialized };
+};

--- a/lib/src/priceLine/PriceLine.tsx
+++ b/lib/src/priceLine/PriceLine.tsx
@@ -15,4 +15,4 @@ const PriceLineRenderFunction = (
 
 const PriceLine = forwardRef(PriceLineRenderFunction);
 PriceLine.displayName = "PriceLine";
-export default PriceLine;
+export { PriceLine };

--- a/lib/src/priceLine/index.ts
+++ b/lib/src/priceLine/index.ts
@@ -1,2 +1,2 @@
-export { default as PriceLine } from "./PriceLine";
+export { PriceLine } from "./PriceLine";
 export type { PriceLineApiRef, PriceLineProps } from "./types";

--- a/lib/src/priceLine/usePriceLine.ts
+++ b/lib/src/priceLine/usePriceLine.ts
@@ -4,8 +4,7 @@ import { useSafeContext } from "@/shared/useSafeContext";
 import type { PriceLineApiRef, PriceLineProps } from "./types";
 
 export const usePriceLine = ({ options, price }: PriceLineProps) => {
-  const { initialized: seriesInitialized, seriesApiRef: series } =
-    useSafeContext(SeriesContext);
+  const { isReady: seriesIsReady, seriesApiRef: series } = useSafeContext(SeriesContext);
 
   const priceLineApiRef = useRef<PriceLineApiRef>({
     _priceLine: null,
@@ -37,10 +36,10 @@ export const usePriceLine = ({ options, price }: PriceLineProps) => {
   });
 
   useLayoutEffect(() => {
-    if (!seriesInitialized) return;
+    if (!seriesIsReady) return;
 
     priceLineApiRef.current.init();
-  }, [seriesInitialized]);
+  }, [seriesIsReady]);
 
   useLayoutEffect(() => {
     return () => {

--- a/lib/src/scales/PriceScale.tsx
+++ b/lib/src/scales/PriceScale.tsx
@@ -15,4 +15,4 @@ const PriceScaleRenderFunction = (
 
 const PriceScale = forwardRef(PriceScaleRenderFunction);
 PriceScale.displayName = "PriceScale";
-export default PriceScale;
+export { PriceScale };

--- a/lib/src/scales/TimeScale.tsx
+++ b/lib/src/scales/TimeScale.tsx
@@ -15,4 +15,4 @@ const TimeScaleRenderFunction = (
 
 const TimeScale = forwardRef(TimeScaleRenderFunction);
 TimeScale.displayName = "TimeScale";
-export default TimeScale;
+export { TimeScale };

--- a/lib/src/scales/index.ts
+++ b/lib/src/scales/index.ts
@@ -1,5 +1,5 @@
-export { default as TimeScale } from "./TimeScale";
-export { default as PriceScale } from "./PriceScale";
+export { TimeScale } from "./TimeScale";
+export { PriceScale } from "./PriceScale";
 export type {
   PriceScaleProps,
   TimeScaleProps,

--- a/lib/src/scales/usePriceScale.ts
+++ b/lib/src/scales/usePriceScale.ts
@@ -4,8 +4,7 @@ import { useSafeContext } from "@/shared/useSafeContext";
 import type { PriceScaleProps, PriceScaleApiRef } from "./types";
 
 export const usePriceScale = ({ options = {}, id }: PriceScaleProps) => {
-  const { initialized: chartInitialized, chartApiRef: chart } =
-    useSafeContext(ChartContext);
+  const { isReady: chartIsReady, chartApiRef: chart } = useSafeContext(ChartContext);
 
   const priceScaleApiRef = useRef<PriceScaleApiRef>({
     _priceScale: null,
@@ -41,10 +40,10 @@ export const usePriceScale = ({ options = {}, id }: PriceScaleProps) => {
   });
 
   useLayoutEffect(() => {
-    if (!chartInitialized) return;
+    if (!chartIsReady) return;
 
     priceScaleApiRef.current.init();
-  }, [chartInitialized]);
+  }, [chartIsReady]);
 
   useLayoutEffect(() => {
     return () => {

--- a/lib/src/scales/useTimeScale.ts
+++ b/lib/src/scales/useTimeScale.ts
@@ -11,8 +11,7 @@ export const useTimeScale = ({
   visibleLogicalRange,
   options = {},
 }: TimeScaleProps) => {
-  const { initialized: chartInitialized, chartApiRef: chart } =
-    useSafeContext(ChartContext);
+  const { isReady: chartIsReady, chartApiRef: chart } = useSafeContext(ChartContext);
 
   if (!chart) {
     throw new Error("Chart context not found");
@@ -52,10 +51,10 @@ export const useTimeScale = ({
   });
 
   useLayoutEffect(() => {
-    if (!chartInitialized) return;
+    if (!chartIsReady) return;
 
     timeScaleApiRef.current.init();
-  }, [chartInitialized]);
+  }, [chartIsReady]);
 
   useLayoutEffect(() => {
     return () => {

--- a/lib/src/series/AreaSeries.tsx
+++ b/lib/src/series/AreaSeries.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import SeriesTemplate from "./SeriesTemplate";
+import { SeriesTemplate } from "./SeriesTemplate";
 import type { SeriesApiRef, SeriesProps } from "./types";
 import type { ForwardedRef } from "react";
 
@@ -16,4 +16,4 @@ const AreaSeriesRenderFunction = (
 
 const AreaSeries = forwardRef(AreaSeriesRenderFunction);
 AreaSeries.displayName = "AreaSeries";
-export default AreaSeries;
+export { AreaSeries };

--- a/lib/src/series/BarSeries.tsx
+++ b/lib/src/series/BarSeries.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import SeriesTemplate from "./SeriesTemplate";
+import { SeriesTemplate } from "./SeriesTemplate";
 import type { SeriesApiRef, SeriesProps } from "./types";
 import type { ForwardedRef } from "react";
 
@@ -16,4 +16,4 @@ const BarSeriesRenderFunction = (
 
 const BarSeries = forwardRef(BarSeriesRenderFunction);
 BarSeries.displayName = "BarSeries";
-export default BarSeries;
+export { BarSeries };

--- a/lib/src/series/BaselineSeries.tsx
+++ b/lib/src/series/BaselineSeries.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import SeriesTemplate from "./SeriesTemplate";
+import { SeriesTemplate } from "./SeriesTemplate";
 import type { SeriesApiRef, SeriesProps } from "./types";
 import type { ForwardedRef } from "react";
 
@@ -16,4 +16,4 @@ const BaselineSeriesRenderFunction = (
 
 const BaselineSeries = forwardRef(BaselineSeriesRenderFunction);
 BaselineSeries.displayName = "BaselineSeries";
-export default BaselineSeries;
+export { BaselineSeries };

--- a/lib/src/series/CandlestickSeries.tsx
+++ b/lib/src/series/CandlestickSeries.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import SeriesTemplate from "./SeriesTemplate";
+import { SeriesTemplate } from "./SeriesTemplate";
 import type { SeriesApiRef, SeriesProps } from "./types";
 import type { ForwardedRef } from "react";
 
@@ -16,4 +16,4 @@ const CandlestickSeriesRenderFunction = (
 
 const CandlestickSeries = forwardRef(CandlestickSeriesRenderFunction);
 CandlestickSeries.displayName = "CandlestickSeries";
-export default CandlestickSeries;
+export { CandlestickSeries };

--- a/lib/src/series/CustomSeries.tsx
+++ b/lib/src/series/CustomSeries.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import SeriesTemplate from "./SeriesTemplate";
+import { SeriesTemplate } from "./SeriesTemplate";
 import type { SeriesApiRef, SeriesProps } from "./types";
 import type { ForwardedRef } from "react";
 
@@ -16,4 +16,4 @@ const CustomSeriesRenderFunction = (
 
 const CustomSeries = forwardRef(CustomSeriesRenderFunction);
 CustomSeries.displayName = "CustomSeries";
-export default CustomSeries;
+export { CustomSeries };

--- a/lib/src/series/HistogramSeries.tsx
+++ b/lib/src/series/HistogramSeries.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import SeriesTemplate from "./SeriesTemplate";
+import { SeriesTemplate } from "./SeriesTemplate";
 import type { SeriesApiRef, SeriesProps } from "./types";
 import type { ForwardedRef } from "react";
 
@@ -16,4 +16,4 @@ const HistogramSeriesRenderFunction = (
 
 const HistogramSeries = forwardRef(HistogramSeriesRenderFunction);
 HistogramSeries.displayName = "HistogramSeries";
-export default HistogramSeries;
+export { HistogramSeries };

--- a/lib/src/series/LineSeries.tsx
+++ b/lib/src/series/LineSeries.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import SeriesTemplate from "./SeriesTemplate";
+import { SeriesTemplate } from "./SeriesTemplate";
 import type { SeriesApiRef, SeriesProps } from "./types";
 import type { ForwardedRef } from "react";
 
@@ -16,4 +16,4 @@ const LineSeriesRenderFunction = (
 
 const LineSeries = forwardRef(LineSeriesRenderFunction);
 LineSeries.displayName = "LineSeries";
-export default LineSeries;
+export { LineSeries };

--- a/lib/src/series/SeriesContext.ts
+++ b/lib/src/series/SeriesContext.ts
@@ -3,6 +3,6 @@ import { type ISeriesContext } from "./types";
 
 export const SeriesContext = createContext<ISeriesContext>({
   seriesApiRef: null,
-  initialized: false,
+  isReady: false,
 });
 SeriesContext.displayName = "SeriesContext";

--- a/lib/src/series/SeriesTemplate.tsx
+++ b/lib/src/series/SeriesTemplate.tsx
@@ -18,7 +18,7 @@ const SeriesTemplateRenderFunction = <T extends SeriesType>(
 ) => {
   const {
     seriesApiRef: { current: seriesApiRef },
-    initialized,
+    isReady,
   } = useSeries(rest);
   useImperativeHandle(ref, () => seriesApiRef, [seriesApiRef]);
 
@@ -26,7 +26,7 @@ const SeriesTemplateRenderFunction = <T extends SeriesType>(
     <SeriesContext.Provider
       value={{
         seriesApiRef,
-        initialized,
+        isReady,
       }}
     >
       {children}

--- a/lib/src/series/SeriesTemplate.tsx
+++ b/lib/src/series/SeriesTemplate.tsx
@@ -4,7 +4,7 @@ import { useSeries } from "./useSeries";
 import type { SeriesType, SeriesTemplateProps, SeriesApiRef } from "./types";
 import type { ForwardedRef } from "react";
 
-type GenericRefComponent = (<T extends SeriesType>(
+type GenericSeriesComponent = (<T extends SeriesType>(
   props: SeriesTemplateProps<T> & {
     ref?: ForwardedRef<SeriesApiRef<T>>;
   }
@@ -34,7 +34,7 @@ const SeriesTemplateRenderFunction = <T extends SeriesType>(
   );
 };
 
-const SeriesTemplate = forwardRef(SeriesTemplateRenderFunction) as GenericRefComponent;
+const SeriesTemplate = forwardRef(SeriesTemplateRenderFunction) as GenericSeriesComponent;
 
 SeriesTemplate.displayName = "SeriesTemplate";
-export default SeriesTemplate;
+export { SeriesTemplate };

--- a/lib/src/series/index.ts
+++ b/lib/src/series/index.ts
@@ -1,8 +1,8 @@
-export { default as LineSeries } from "./LineSeries";
-export { default as HistogramSeries } from "./HistogramSeries";
-export { default as CandlestickSeries } from "./CandlestickSeries";
-export { default as AreaSeries } from "./AreaSeries";
-export { default as BaselineSeries } from "./BaselineSeries";
-export { default as BarSeries } from "./BarSeries";
-export { default as CustomSeries } from "./CustomSeries";
+export { LineSeries } from "./LineSeries";
+export { HistogramSeries } from "./HistogramSeries";
+export { CandlestickSeries } from "./CandlestickSeries";
+export { AreaSeries } from "./AreaSeries";
+export { BaselineSeries } from "./BaselineSeries";
+export { BarSeries } from "./BarSeries";
+export { CustomSeries } from "./CustomSeries";
 export type { SeriesApiRef, SeriesType, SeriesProps, SeriesOptions } from "./types";

--- a/lib/src/series/types.ts
+++ b/lib/src/series/types.ts
@@ -16,6 +16,7 @@ export type SeriesParameters<T extends SeriesType> = {
   data: SeriesDataItemTypeMap[T][];
   reactive?: boolean;
   options?: SeriesOptions<T>;
+  pane?: boolean;
 } & (T extends "Custom" ? CustomSeriesUniqueProps : {});
 
 export type SeriesTemplateProps<T extends SeriesType> = {
@@ -32,7 +33,7 @@ export type SeriesApiRef<T extends SeriesType> = {
 
 export interface ISeriesContext {
   seriesApiRef: SeriesApiRef<SeriesType> | null;
-  initialized: boolean;
+  isReady: boolean;
 }
 
 export type SeriesOptions<T extends SeriesType> = SeriesPartialOptionsMap[T];

--- a/lib/src/series/types.ts
+++ b/lib/src/series/types.ts
@@ -16,7 +16,7 @@ export type SeriesParameters<T extends SeriesType> = {
   data: SeriesDataItemTypeMap[T][];
   reactive?: boolean;
   options?: SeriesOptions<T>;
-  pane?: boolean;
+  isPane?: boolean;
 } & (T extends "Custom" ? CustomSeriesUniqueProps : {});
 
 export type SeriesTemplateProps<T extends SeriesType> = {

--- a/lib/src/series/useSeries.ts
+++ b/lib/src/series/useSeries.ts
@@ -6,8 +6,9 @@ import {
   BaselineSeries,
   BarSeries,
 } from "lightweight-charts";
-import { useLayoutEffect, useRef, useState } from "react";
+import { useContext, useLayoutEffect, useRef, useState } from "react";
 import { ChartContext } from "@/chart/ChartContext";
+import { PaneContext } from "@/pane/PaneContext";
 import { BaseInternalError } from "@/shared/InternalError";
 import { useSafeContext } from "@/shared/useSafeContext";
 import type {
@@ -29,6 +30,8 @@ export const useSeries = <T extends SeriesType>({
 }: Omit<SeriesTemplateProps<T>, "children">) => {
   const { initialized: chartInitialized, chartApiRef: chart } =
     useSafeContext(ChartContext);
+  const pane = useContext(PaneContext);
+  const paneId = pane?.paneId;
   const [initialized, setInitialized] = useState(false);
 
   const seriesApiRef = useRef<SeriesApiRef<T>>({
@@ -53,12 +56,14 @@ export const useSeries = <T extends SeriesType>({
           // TODO: Fix this type cast and infer the correct type
           (this._series as unknown as ISeriesApi<"Custom">) = chartApi.addCustomSeries(
             plugin,
-            options
+            options,
+            paneId
           );
         } else {
           this._series = chartApi.addSeries(
             seriesMap[type as SeriesTypeWithoutCustom] as SeriesDefinition<T>,
-            options
+            options,
+            paneId
           );
         }
 

--- a/lib/src/series/useSeries.ts
+++ b/lib/src/series/useSeries.ts
@@ -26,7 +26,7 @@ export const useSeries = <T extends SeriesType>({
   data,
   options = {},
   reactive = true,
-  pane,
+  isPane,
   ...rest
 }: Omit<SeriesTemplateProps<T>, "children">) => {
   const { isReady: chartIsReady, chartApiRef: chart } = useSafeContext(ChartContext);
@@ -55,19 +55,19 @@ export const useSeries = <T extends SeriesType>({
           (this._series as unknown as ISeriesApi<"Custom">) = chartApi.addCustomSeries(
             plugin,
             options,
-            pane ? panesCount : 0
+            isPane ? panesCount : 0
           );
         } else {
           this._series = chartApi.addSeries(
             seriesMap[type as SeriesTypeWithoutCustom] as SeriesDefinition<T>,
             options,
-            pane ? panesCount : 0
+            isPane ? panesCount : 0
           );
         }
 
         setIsReady(true);
         this._series?.setData(data);
-        pane && incrementPaneCount();
+        isPane && incrementPaneCount();
       }
 
       return this._series;
@@ -77,7 +77,7 @@ export const useSeries = <T extends SeriesType>({
         chart?.api()?.removeSeries(this._series);
         this._series = null;
         setIsReady(false);
-        pane && decrementPaneCount();
+        isPane && decrementPaneCount();
       }
     },
   });
@@ -111,16 +111,16 @@ export const useSeries = <T extends SeriesType>({
   }, [options]);
 
   useLayoutEffect(() => {
-    if (!chart || pane === undefined) return;
+    if (!chart || isPane === undefined) return;
 
-    if (pane) {
+    if (isPane) {
       incrementPaneCount();
       seriesApiRef.current.api()?.moveToPane(panesCount);
     } else {
       decrementPaneCount();
       seriesApiRef.current.api()?.moveToPane(0);
     }
-  }, [pane]);
+  }, [isPane]);
 
   return { isReady, seriesApiRef };
 };

--- a/lib/src/shared/useSafeContext.ts
+++ b/lib/src/shared/useSafeContext.ts
@@ -1,13 +1,14 @@
 import { type Context, useContext } from "react";
+import { BaseInternalError } from "./InternalError";
 
-export const useSafeContext = <T>(context: Context<T>) => {
+export const useSafeContext = <T>(context: Context<T>, errorMessage?: string) => {
   const currentContextValue = useContext(context);
 
   if (!currentContextValue) {
     const ctxName = context.name;
-    throw new Error(
-      `${ctxName} not found. You can access context value only inside its Provider.`
-    );
+    throw new BaseInternalError(errorMessage ?? `${ctxName} not found.`, {
+      isOperational: true,
+    });
   }
 
   return currentContextValue;

--- a/lib/src/watermark/useWatermark.ts
+++ b/lib/src/watermark/useWatermark.ts
@@ -5,8 +5,7 @@ import { useSafeContext } from "@/shared/useSafeContext";
 import type { WatermarkApiRef, WatermarkProps, WatermarkType } from "./types";
 
 const useWatermark = <T extends WatermarkType>(props: WatermarkProps<T>) => {
-  const { initialized: chartInitialized, chartApiRef: chart } =
-    useSafeContext(ChartContext);
+  const { isReady: chartIsReady, chartApiRef: chart } = useSafeContext(ChartContext);
 
   const watermarkApiRef = useRef<WatermarkApiRef<T>>({
     _watermark: null,
@@ -39,10 +38,10 @@ const useWatermark = <T extends WatermarkType>(props: WatermarkProps<T>) => {
   } as WatermarkApiRef<T>);
 
   useLayoutEffect(() => {
-    if (!chartInitialized) return;
+    if (!chartIsReady) return;
 
     watermarkApiRef.current.init();
-  }, [chartInitialized]);
+  }, [chartIsReady]);
 
   useLayoutEffect(() => {
     return () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^6.4.10",
         "@mui/material": "^6.4.7",
+        "@react-hook/resize-observer": "^2.0.2",
         "copy-to-clipboard": "^3.3.3",
         "lightweight-charts-react-components": "file:../lib",
         "react": "^19.1.0",
@@ -2189,6 +2190,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@react-hook/latest": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@react-hook/latest/-/latest-1.0.3.tgz",
+      "integrity": "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@react-hook/passive-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@react-hook/resize-observer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@react-hook/resize-observer/-/resize-observer-2.0.2.tgz",
+      "integrity": "sha512-tzKKzxNpfE5TWmxuv+5Ae3IF58n0FQgQaWJmcbYkjXTRZATXxClnTprQ2uuYygYTpu1pqbBskpwMpj6jpT1djA==",
+      "dependencies": {
+        "@react-hook/latest": "^1.0.2",
+        "@react-hook/passive-layout-effect": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {


### PR DESCRIPTION
## Short Summary

This diff adds support for Panes api via `pane` prop of `Series` component, which allows to render series as a separate pane [pane](https://tradingview.github.io/lightweight-charts/docs/panes).
It is not a final version, i'm not satisfied with this implementation at all, and there are some developments in the `lib/src/panes` folder.
In examples app this diff adds Tooltip (single series and multiple series tooltip) and Panes examples.

## Changes made

<!-- Provide a detailed description of the changes introduced in this PR -->

- Series `pane` prop
- Changes in the `Chart` component api.
- Panes and Tooltips examples, some styling applied through over the examples app
- Applying some lint changes 

## Related Issues

Fixes #53 related #56 #55 
