### PR TITLE
feat: drop commonjs support

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Feat
+- drop commonjs support
 
 ## [0.3.2] - 2025-04-21
 ### Fix

--- a/lib/package.json
+++ b/lib/package.json
@@ -22,16 +22,15 @@
     "url": "https://github.com/ukorvl/lightweight-charts-react-components/issues"
   },
   "type": "module",
-  "main": "./dist/lightweight-charts-react-components.cjs",
-  "module": "./dist/lightweight-charts-react-components.js",
+  "main": "./dist/lightweight-charts-react-components.mjs",
+  "module": "./dist/lightweight-charts-react-components.mjs",
   "types": "./dist/index.d.ts",
   "unpkg": "./dist/lightweight-charts-react-components.standalone.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/lightweight-charts-react-components.js",
-      "require": "./dist/lightweight-charts-react-components.cjs"
+      "import": "./dist/lightweight-charts-react-components.mjs"
     }
   },
   "files": [

--- a/lib/rslib.config.ts
+++ b/lib/rslib.config.ts
@@ -49,18 +49,6 @@ export default defineConfig({
       ],
     },
     {
-      format: "cjs",
-      syntax: "es5",
-      banner: {
-        js: banner,
-      },
-      output: {
-        filename: {
-          js: removeDistPrefix(packageJson.main),
-        },
-      },
-    },
-    {
       format: "umd",
       umdName: "LightweightChartsReactComponents",
       syntax: "es5",


### PR DESCRIPTION
## Short Summary

This diff drops commonjs support since lightweight-charts itself does not support it.

## Changes made

<!-- Provide a detailed description of the changes introduced in this PR -->

- only esm exports left


## Related Issues


