### PR TITLE
feat: add infinite data example and fix time scale options on init

### DIFF
--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -3,6 +3,7 @@ import { colors } from "./colors";
 import { BasicSeries } from "./samples/BasicSeries/BasicSeries";
 import { CompareSeries } from "./samples/CompareSeries/CompareSeries";
 import { CustomSeries } from "./samples/CustomSeries/CustomSeries";
+import { InfiniteData } from "./samples/InfiniteData/InfiniteData";
 import { WithLegend } from "./samples/Legend/WithLegend";
 import { Markers } from "./samples/Markers/Markers";
 import { Panes } from "./samples/Panes/Panes";
@@ -127,6 +128,7 @@ export const App = () => {
           <Scales />
           <Tooltips />
           <Panes />
+          <InfiniteData />
         </LayoutGrid>
       </Stack>
       <Footer

--- a/examples/src/common/generateSeriesData.ts
+++ b/examples/src/common/generateSeriesData.ts
@@ -7,8 +7,17 @@ type GenerateHistogramDataOptions = {
   downColor?: string;
 };
 
-const generateLineData = (length: number): LineData<string>[] => {
-  const start = dayjs().subtract(length, "day");
+type GenerateLineDataOptions = {
+  lastItemTime?: string;
+};
+
+const generateLineData = (
+  length: number,
+  { lastItemTime }: GenerateLineDataOptions = {}
+): LineData<string>[] => {
+  const start = lastItemTime
+    ? dayjs(lastItemTime).subtract(length, "day")
+    : dayjs().subtract(length, "day");
   let lastValue = Math.floor(Math.random() * 100);
 
   return createStubArray(length).map((_, i) => {

--- a/examples/src/common/utils.ts
+++ b/examples/src/common/utils.ts
@@ -49,10 +49,13 @@ const deepMergePlainObjects = <
   return result as T | O;
 };
 
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
 export {
   typedObjectKeys,
   createStubArray,
   encodeInlineSvg,
   typedObjectEntries,
   deepMergePlainObjects,
+  sleep,
 };

--- a/examples/src/samples.ts
+++ b/examples/src/samples.ts
@@ -67,6 +67,11 @@ const samplesLinks = {
     codesandbox: "",
     stackblitz: "",
   },
+  InfiniteData: {
+    github: `${githubSamplesLocation}/InfiniteData`,
+    codesandbox: "",
+    stackblitz: "",
+  },
 } as const;
 
 export { samplesLinks, type SampleConfig };

--- a/examples/src/samples/BasicSeries/sandbox/package.json
+++ b/examples/src/samples/BasicSeries/sandbox/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "vite": "^5.0.0",
+    "@types/react": "^19.1.0",
     "@vitejs/plugin-react": "^4.0.0",
     "typescript": "^5.3.0"
   }

--- a/examples/src/samples/InfiniteData/InfiniteData.tsx
+++ b/examples/src/samples/InfiniteData/InfiniteData.tsx
@@ -1,0 +1,88 @@
+import { debounce, useTheme } from "@mui/material";
+import {
+  Chart,
+  LineSeries,
+  TimeScale,
+  WatermarkText,
+} from "lightweight-charts-react-components";
+import { useCallback, useMemo } from "react";
+import { colors } from "@/colors";
+import { withChartCommonOptions } from "@/common/chartCommonOptions";
+import { samplesLinks } from "@/samples";
+import { useInfiniteDataStore } from "./infiniteDataStore";
+import { ChartWidgetCard } from "../../ui/ChartWidgetCard";
+import type { LogicalRange, LogicalRangeChangeEventHandler } from "lightweight-charts";
+
+const InfiniteData = () => {
+  const { data, loading, fetchMoreData } = useInfiniteDataStore();
+  const theme = useTheme();
+
+  const debouncedFetchMore = useMemo(
+    () =>
+      debounce((r: LogicalRange) => {
+        const { from } = r;
+        fetchMoreData(Math.floor(50 - from));
+      }, 150),
+    [fetchMoreData]
+  );
+
+  const onVisibleLogicalRangeChange: LogicalRangeChangeEventHandler = useCallback(
+    r => {
+      if (loading || !r) return;
+
+      if (r.from < 5) {
+        debouncedFetchMore(r);
+      }
+    },
+    [debouncedFetchMore, loading]
+  );
+
+  const chartOptions = useMemo(
+    () =>
+      withChartCommonOptions(
+        loading
+          ? {
+              layout: {
+                background: {
+                  color: `${colors.gray}05`,
+                },
+                textColor: colors.gray,
+              },
+            }
+          : {}
+      ),
+    [withChartCommonOptions, loading]
+  );
+
+  return (
+    <ChartWidgetCard
+      title="Infinite data"
+      subTitle="Load more data on scroll"
+      sampleConfig={samplesLinks.InfiniteData}
+    >
+      <Chart options={chartOptions} containerProps={{ style: { flexGrow: "1" } }}>
+        <LineSeries data={data} options={{ color: colors.green }} />
+        <TimeScale
+          options={{
+            barSpacing: 10,
+            fixRightEdge: true,
+          }}
+          onVisibleLogicalRangeChange={onVisibleLogicalRangeChange}
+        />
+        <WatermarkText
+          visible={loading}
+          lines={[
+            {
+              text: "Loading more data...",
+              color: `${colors.gray}75`,
+              fontSize: 36,
+              fontFamily: theme.typography.fontFamily,
+            },
+          ]}
+        />
+      </Chart>
+    </ChartWidgetCard>
+  );
+};
+
+export { InfiniteData };

--- a/examples/src/samples/InfiniteData/infiniteDataStore.ts
+++ b/examples/src/samples/InfiniteData/infiniteDataStore.ts
@@ -1,0 +1,38 @@
+import { create } from "zustand";
+import { generateLineData } from "@/common/generateSeriesData";
+import { sleep } from "@/common/utils";
+import type { LineData } from "lightweight-charts";
+
+interface InfiniteDataStore {
+  data: LineData<string>[];
+  loading: boolean;
+  fetchMoreData: (n: number) => Promise<void>;
+}
+
+const initialData = generateLineData(100);
+
+const useInfiniteDataStore = create<InfiniteDataStore>((set, get) => ({
+  data: initialData,
+  loading: false,
+  fetchMoreData: async (numberBarsToLoad: number) => {
+    const { data } = get();
+
+    set({ loading: true });
+
+    try {
+      set({ loading: true });
+      await sleep(500);
+
+      const prevData = generateLineData(numberBarsToLoad, {
+        lastItemTime: data[0].time,
+      });
+
+      set({ data: [...prevData, ...data] });
+      set({ loading: false });
+    } catch {
+      set({ loading: false });
+    }
+  },
+}));
+
+export { useInfiniteDataStore };

--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -1,10 +1,11 @@
 import path from "node:path";
 import react from "@vitejs/plugin-react";
-import { defineConfig, loadEnv } from "vite";
+import { loadEnv } from "vite";
 import checker from "vite-plugin-checker";
 import viteCompression from "vite-plugin-compression";
 import htmlPlugin, { type Options } from "vite-plugin-html-config";
 import { homepage, description } from "./package.json";
+import type { UserConfigFn } from "vite";
 
 const env = loadEnv("", process.cwd(), "");
 
@@ -130,7 +131,7 @@ export const htmlConfig: Options = {
   ],
 };
 
-export default defineConfig({
+const getUserConfig: UserConfigFn = ({ command }) => ({
   server: {
     port: Number(env.PORT) || 5173,
   },
@@ -138,9 +139,13 @@ export default defineConfig({
     react(),
     viteCompression(),
     htmlPlugin(htmlConfig),
-    checker({
-      typescript: true,
-    }),
+    ...(command === "build"
+      ? [
+          checker({
+            typescript: true,
+          }),
+        ]
+      : []),
   ],
   build: {
     emptyOutDir: true,
@@ -158,3 +163,5 @@ export default defineConfig({
     },
   },
 });
+
+export default getUserConfig;

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fix
+- fix time scale options not being applied on init
 
 ## [0.3.3] - 2025-04-21
 ### Feat

--- a/lib/src/scales/useTimeScale.ts
+++ b/lib/src/scales/useTimeScale.ts
@@ -23,24 +23,38 @@ export const useTimeScale = ({
       return this._timeScale;
     },
     init() {
-      if (!this._timeScale) {
-        const chartApi = chart?.api();
+      if (this._timeScale) {
+        return this._timeScale;
+      }
 
-        if (!chartApi) {
-          return null;
-        }
+      const chartApi = chart?.api();
 
-        this._timeScale = chartApi.timeScale();
+      if (!chartApi) {
+        return null;
+      }
 
-        this._timeScale.applyOptions(options);
+      this._timeScale = chartApi.timeScale();
 
-        if (visibleRange) {
-          this._timeScale.setVisibleRange(visibleRange);
-        }
+      this._timeScale.applyOptions(options);
 
-        if (visibleLogicalRange) {
-          this._timeScale.setVisibleLogicalRange(visibleLogicalRange);
-        }
+      if (visibleRange) {
+        this._timeScale.setVisibleRange(visibleRange);
+      }
+
+      if (visibleLogicalRange) {
+        this._timeScale.setVisibleLogicalRange(visibleLogicalRange);
+      }
+
+      if (onVisibleTimeRangeChange) {
+        this._timeScale.subscribeVisibleTimeRangeChange(onVisibleTimeRangeChange);
+      }
+
+      if (onVisibleLogicalRangeChange) {
+        this._timeScale.subscribeVisibleLogicalRangeChange(onVisibleLogicalRangeChange);
+      }
+
+      if (onSizeChange) {
+        this._timeScale.subscribeSizeChange(onSizeChange);
       }
 
       return this._timeScale;


### PR DESCRIPTION
## Short Summary

<!-- Provide a brief summary of the changes introduced in this PR -->

This diff adds the example of Infinite data loading by utilizing `subscribeVisibleLogicalRangeChange` time scale method.

## Changes made

<!-- Provide a detailed description of the changes introduced in this PR -->

- Adds chart infinite data example
- Fixes time scale component on init settings
- Limits vite checker plugin usage to build command only in examples app

## Related Issues

<!-- Mention the issues that are being closed by this PR -->

Fixes #59 
