### PR TITLE
feat: add time scale fit content trigger helper component

### DIFF
--- a/examples/src/samples/BasicSeries/BasicSeries.tsx
+++ b/examples/src/samples/BasicSeries/BasicSeries.tsx
@@ -1,5 +1,9 @@
 import { Tab, Tabs } from "@mui/material";
-import { Chart } from "lightweight-charts-react-components";
+import {
+  Chart,
+  TimeScale,
+  TimeScaleFitContentTrigger,
+} from "lightweight-charts-react-components";
 import { chartCommonOptions } from "@/common/chartCommonOptions";
 import { typedObjectKeys } from "@/common/utils";
 import { samplesLinks } from "@/samples";
@@ -37,6 +41,9 @@ const BasicSeries = () => {
       </Tabs>
       <Chart options={chartCommonOptions} containerProps={{ style: { flexGrow: "1" } }}>
         {Component && <Component data={seriesData} options={options} reactive={false} />}
+        <TimeScale>
+          <TimeScaleFitContentTrigger deps={[]} />
+        </TimeScale>
       </Chart>
     </ChartWidgetCard>
   );

--- a/examples/src/samples/CompareSeries/CompareSeries.tsx
+++ b/examples/src/samples/CompareSeries/CompareSeries.tsx
@@ -1,6 +1,11 @@
 import { Chip } from "@mui/material";
 import { CrosshairMode } from "lightweight-charts";
-import { AreaSeries, Chart } from "lightweight-charts-react-components";
+import {
+  AreaSeries,
+  Chart,
+  TimeScale,
+  TimeScaleFitContentTrigger,
+} from "lightweight-charts-react-components";
 import { colors } from "@/colors";
 import { withChartCommonOptions } from "@/common/chartCommonOptions";
 import { typedObjectEntries } from "@/common/utils";
@@ -89,6 +94,9 @@ const CompareSeries = () => {
           .map(([key, { Component, data, options }]) => {
             return <Component key={key} data={data} options={options} />;
           })}
+        <TimeScale>
+          <TimeScaleFitContentTrigger deps={[]} />
+        </TimeScale>
       </Chart>
     </ChartWidgetCard>
   );

--- a/examples/src/samples/CustomSeries/CustomSeries.tsx
+++ b/examples/src/samples/CustomSeries/CustomSeries.tsx
@@ -1,6 +1,8 @@
 import {
   Chart,
   CustomSeries as CustomSeriesComponent,
+  TimeScale,
+  TimeScaleFitContentTrigger,
 } from "lightweight-charts-react-components";
 import { chartCommonOptions } from "@/common/chartCommonOptions";
 import { samplesLinks } from "@/samples";
@@ -38,6 +40,9 @@ const CustomSeries = () => {
           ]}
           plugin={new GroupedBarsSeries()}
         />
+        <TimeScale>
+          <TimeScaleFitContentTrigger deps={[]} />
+        </TimeScale>
       </Chart>
     </ChartWidgetCard>
   );

--- a/examples/src/samples/InfiniteData/InfiniteData.tsx
+++ b/examples/src/samples/InfiniteData/InfiniteData.tsx
@@ -3,6 +3,7 @@ import {
   Chart,
   LineSeries,
   TimeScale,
+  TimeScaleFitContentTrigger,
   WatermarkText,
 } from "lightweight-charts-react-components";
 import { useCallback, useMemo } from "react";
@@ -68,7 +69,9 @@ const InfiniteData = () => {
             fixRightEdge: true,
           }}
           onVisibleLogicalRangeChange={onVisibleLogicalRangeChange}
-        />
+        >
+          <TimeScaleFitContentTrigger deps={[]} />
+        </TimeScale>
         <WatermarkText
           visible={loading}
           lines={[

--- a/examples/src/samples/Legend/WithLegend.tsx
+++ b/examples/src/samples/Legend/WithLegend.tsx
@@ -7,7 +7,12 @@ import {
   Typography,
 } from "@mui/material";
 import { CrosshairMode } from "lightweight-charts";
-import { CandlestickSeries, Chart } from "lightweight-charts-react-components";
+import {
+  CandlestickSeries,
+  Chart,
+  TimeScale,
+  TimeScaleFitContentTrigger,
+} from "lightweight-charts-react-components";
 import { colors } from "@/colors";
 import { withChartCommonOptions } from "@/common/chartCommonOptions";
 import { samplesLinks } from "@/samples";
@@ -79,6 +84,9 @@ const WithLegend = () => {
               wickDownColor: colors.red,
             }}
           />
+          <TimeScale>
+            <TimeScaleFitContentTrigger deps={[]} />
+          </TimeScale>
         </Chart>
         {legendData !== null && legendVisible && (
           <Legend>

--- a/examples/src/samples/Markers/Markers.tsx
+++ b/examples/src/samples/Markers/Markers.tsx
@@ -1,5 +1,11 @@
 import { FormControlLabel, FormGroup, Switch } from "@mui/material";
-import { CandlestickSeries, Chart, Markers } from "lightweight-charts-react-components";
+import {
+  CandlestickSeries,
+  Chart,
+  Markers,
+  TimeScale,
+  TimeScaleFitContentTrigger,
+} from "lightweight-charts-react-components";
 import { colors } from "@/colors";
 import { chartCommonOptions } from "@/common/chartCommonOptions";
 import { samplesLinks } from "@/samples";
@@ -43,6 +49,9 @@ const MarkersSample = () => {
         >
           <Markers markers={getMarkersData()} />
         </CandlestickSeries>
+        <TimeScale>
+          <TimeScaleFitContentTrigger deps={[]} />
+        </TimeScale>
       </Chart>
     </ChartWidgetCard>
   );

--- a/examples/src/samples/Panes/Panes.tsx
+++ b/examples/src/samples/Panes/Panes.tsx
@@ -5,6 +5,8 @@ import {
   HistogramSeries,
   LineSeries,
   PriceLine,
+  TimeScale,
+  TimeScaleFitContentTrigger,
 } from "lightweight-charts-react-components";
 import { colors } from "@/colors";
 import { withChartCommonOptions } from "@/common/chartCommonOptions";
@@ -55,6 +57,9 @@ const Panes = () => {
         })}
         containerProps={{ style: { flexGrow: "1" } }}
       >
+        <TimeScale>
+          <TimeScaleFitContentTrigger deps={[]} />
+        </TimeScale>
         <CandlestickSeries
           data={ohlcData}
           options={{

--- a/examples/src/samples/RangeSwitcher/RangeSwitcher.tsx
+++ b/examples/src/samples/RangeSwitcher/RangeSwitcher.tsx
@@ -1,5 +1,10 @@
 import { Button, ButtonGroup } from "@mui/material";
-import { AreaSeries, Chart } from "lightweight-charts-react-components";
+import {
+  AreaSeries,
+  Chart,
+  TimeScale,
+  TimeScaleFitContentTrigger,
+} from "lightweight-charts-react-components";
 import { colors } from "@/colors";
 import { withChartCommonOptions } from "@/common/chartCommonOptions";
 import { typedObjectKeys } from "@/common/utils";
@@ -57,6 +62,9 @@ const RangeSwitcher = () => {
         containerProps={{ style: { flexGrow: "1" } }}
       >
         <AreaSeries options={seriesCustomOptions} data={data} />
+        <TimeScale>
+          <TimeScaleFitContentTrigger deps={[]} />
+        </TimeScale>
       </Chart>
     </ChartWidgetCard>
   );

--- a/examples/src/samples/Scales/Scales.tsx
+++ b/examples/src/samples/Scales/Scales.tsx
@@ -1,5 +1,11 @@
 import { FormControl, FormHelperText, MenuItem, Select } from "@mui/material";
-import { AreaSeries, Chart, PriceScale } from "lightweight-charts-react-components";
+import {
+  AreaSeries,
+  Chart,
+  PriceScale,
+  TimeScale,
+  TimeScaleFitContentTrigger,
+} from "lightweight-charts-react-components";
 import { colors } from "@/colors";
 import { chartCommonOptions } from "@/common/chartCommonOptions";
 import { samplesLinks } from "@/samples";
@@ -116,6 +122,9 @@ const Scales = () => {
             />
           </AreaSeries>
         )}
+        <TimeScale>
+          <TimeScaleFitContentTrigger deps={[]} />
+        </TimeScale>
       </Chart>
     </ChartWidgetCard>
   );

--- a/examples/src/samples/Tooltips/Tooltips.tsx
+++ b/examples/src/samples/Tooltips/Tooltips.tsx
@@ -1,6 +1,11 @@
 import { Circle } from "@mui/icons-material";
 import { Box, Grow, Stack, Tab, Tabs, Typography } from "@mui/material";
-import { Chart, LineSeries } from "lightweight-charts-react-components";
+import {
+  Chart,
+  LineSeries,
+  TimeScale,
+  TimeScaleFitContentTrigger,
+} from "lightweight-charts-react-components";
 import { useMemo, useRef } from "react";
 import { colors } from "@/colors";
 import { withChartCommonOptions } from "@/common/chartCommonOptions";
@@ -130,6 +135,9 @@ const BasicTooltipChart = () => {
           {time}
         </Typography>
       </Tooltip>
+      <TimeScale>
+        <TimeScaleFitContentTrigger deps={[]} />
+      </TimeScale>
     </Chart>
   );
 };
@@ -218,6 +226,9 @@ const MultipleSeriesTooltipChart = () => {
           {time}
         </Typography>
       </Tooltip>
+      <TimeScale>
+        <TimeScaleFitContentTrigger deps={[]} />
+      </TimeScale>
     </Chart>
   );
 };

--- a/examples/src/samples/Watermark/Watermark.tsx
+++ b/examples/src/samples/Watermark/Watermark.tsx
@@ -1,5 +1,10 @@
 import { Tab, Tabs } from "@mui/material";
-import { AreaSeries, Chart } from "lightweight-charts-react-components";
+import {
+  AreaSeries,
+  Chart,
+  TimeScale,
+  TimeScaleFitContentTrigger,
+} from "lightweight-charts-react-components";
 import { colors } from "@/colors";
 import { chartCommonOptions } from "@/common/chartCommonOptions";
 import { samplesLinks } from "@/samples";
@@ -42,6 +47,9 @@ const Watermark = () => {
           }}
         />
         <WatermarkComponent />
+        <TimeScale>
+          <TimeScaleFitContentTrigger deps={[]} />
+        </TimeScale>
       </Chart>
     </ChartWidgetCard>
   );

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fix
 - fix time scale options not being applied on init
+- feat: add `<TimeScaleFitContentTrigger>` component
 
 ## [0.3.3] - 2025-04-21
 ### Feat

--- a/lib/src/scales/TimeScale.tsx
+++ b/lib/src/scales/TimeScale.tsx
@@ -1,16 +1,29 @@
 import { forwardRef, useImperativeHandle } from "react";
+import { TimeScaleContext } from "./TimeScaleContext";
 import { useTimeScale } from "./useTimeScale";
 import type { TimeScaleApiRef, TimeScaleProps } from "./types";
 import type { ForwardedRef } from "react";
 
 const TimeScaleRenderFunction = (
-  props: TimeScaleProps,
+  { children, ...props }: TimeScaleProps,
   ref: ForwardedRef<TimeScaleApiRef>
 ) => {
-  const timeScaleApiRef = useTimeScale(props);
-  useImperativeHandle(ref, () => timeScaleApiRef.current, [timeScaleApiRef]);
+  const {
+    timeScaleApiRef: { current: timeScaleApiRef },
+    isReady,
+  } = useTimeScale(props);
+  useImperativeHandle(ref, () => timeScaleApiRef, [timeScaleApiRef]);
 
-  return null;
+  return (
+    <TimeScaleContext.Provider
+      value={{
+        timeScaleApiRef,
+        isReady,
+      }}
+    >
+      {children}
+    </TimeScaleContext.Provider>
+  );
 };
 
 const TimeScale = forwardRef(TimeScaleRenderFunction);

--- a/lib/src/scales/TimeScaleContext.ts
+++ b/lib/src/scales/TimeScaleContext.ts
@@ -1,0 +1,6 @@
+import { createContext } from "react";
+import { type ITimeScaleContext } from "./types";
+
+const TimeScaleContext = createContext<ITimeScaleContext | null>(null);
+TimeScaleContext.displayName = "TimeScaleContext";
+export { TimeScaleContext };

--- a/lib/src/scales/TimeScaleFitContentTrigger.tsx
+++ b/lib/src/scales/TimeScaleFitContentTrigger.tsx
@@ -1,0 +1,10 @@
+import { useTimeScaleFitContentTrigger } from "./useTimeScaleFitContentTrigger";
+import type { TimeScaleFitContentTriggerProps } from "./types";
+
+const TimeScaleFitContentTrigger = ({ deps }: TimeScaleFitContentTriggerProps) => {
+  useTimeScaleFitContentTrigger({ deps });
+
+  return null;
+};
+
+export { TimeScaleFitContentTrigger };

--- a/lib/src/scales/index.ts
+++ b/lib/src/scales/index.ts
@@ -1,8 +1,10 @@
 export { TimeScale } from "./TimeScale";
 export { PriceScale } from "./PriceScale";
+export { TimeScaleFitContentTrigger } from "./TimeScaleFitContentTrigger";
 export type {
   PriceScaleProps,
   TimeScaleProps,
   PriceScaleApiRef,
   TimeScaleApiRef,
+  TimeScaleFitContentTriggerProps,
 } from "./types";

--- a/lib/src/scales/types.ts
+++ b/lib/src/scales/types.ts
@@ -10,6 +10,7 @@ import type {
   TimeScaleOptions as TimeScaleNativeOptions,
   PriceScaleOptions as PriceScaleNativeOptions,
 } from "lightweight-charts";
+import type { DependencyList, ReactNode } from "react";
 
 export type TimeScaleOptions = DeepPartial<TimeScaleNativeOptions>;
 export type PriceScaleOptions = DeepPartial<PriceScaleNativeOptions>;
@@ -36,9 +37,19 @@ export type TimeScaleProps = {
   visibleRange?: IRange<Time>;
   visibleLogicalRange?: IRange<number>;
   options?: TimeScaleOptions;
+  children?: ReactNode;
 };
 
 export type PriceScaleProps = {
   options?: PriceScaleOptions;
   id: string;
 };
+
+export type TimeScaleFitContentTriggerProps = {
+  deps: DependencyList;
+};
+
+export interface ITimeScaleContext {
+  timeScaleApiRef: TimeScaleApiRef | null;
+  isReady: boolean;
+}

--- a/lib/src/scales/useTimeScale.ts
+++ b/lib/src/scales/useTimeScale.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { useSafeContext } from "@/_shared/useSafeContext";
 import { ChartContext } from "@/chart/ChartContext";
 import type { TimeScaleApiRef, TimeScaleProps } from "./types";
@@ -10,8 +10,9 @@ export const useTimeScale = ({
   visibleRange,
   visibleLogicalRange,
   options = {},
-}: TimeScaleProps) => {
+}: Omit<TimeScaleProps, "children">) => {
   const { isReady: chartIsReady, chartApiRef: chart } = useSafeContext(ChartContext);
+  const [isReady, setIsReady] = useState(false);
 
   if (!chart) {
     throw new Error("Chart context not found");
@@ -57,10 +58,13 @@ export const useTimeScale = ({
         this._timeScale.subscribeSizeChange(onSizeChange);
       }
 
+      setIsReady(true);
+
       return this._timeScale;
     },
     clear() {
       this._timeScale = null;
+      setIsReady(false);
     },
   });
 
@@ -150,5 +154,5 @@ export const useTimeScale = ({
     }
   }, [visibleLogicalRange]);
 
-  return timeScaleApiRef;
+  return { timeScaleApiRef, isReady };
 };

--- a/lib/src/scales/useTimeScaleFitContentTrigger.ts
+++ b/lib/src/scales/useTimeScaleFitContentTrigger.ts
@@ -1,0 +1,24 @@
+import { useLayoutEffect } from "react";
+import { useSafeContext } from "@/_shared/useSafeContext";
+import { TimeScaleContext } from "./TimeScaleContext";
+import type { TimeScaleFitContentTriggerProps } from "./types";
+
+const useTimeScaleFitContentTrigger = ({ deps }: TimeScaleFitContentTriggerProps) => {
+  const timeScaleContext = useSafeContext(TimeScaleContext);
+  const { timeScaleApiRef, isReady } = timeScaleContext;
+
+  useLayoutEffect(() => {
+    if (!isReady || !timeScaleApiRef) {
+      return;
+    }
+
+    const timeScale = timeScaleApiRef.api();
+    queueMicrotask(() => {
+      if (timeScale) {
+        timeScale.fitContent();
+      }
+    });
+  }, [...deps, isReady]);
+};
+
+export { useTimeScaleFitContentTrigger };


### PR DESCRIPTION
## Short Summary

<!-- Provide a brief summary of the changes introduced in this PR -->

This diff introduces a new `TimeScaleFitContentTrigger` component, which is a helper component with `deps` prop. A developer ca specify any `deps` which work exactly like React `useEffect` dependencies, triggering `timeScale.fitContent()` handler.
If a developer specifies `deps` as an empty array using array literal, `fitContent()` is triggered once when timeScale is ready (most likely `[]` dependencies in `useEffect`).

Example of usage:
```jsx
<TimeScale>
    <TimeScaleFitContentTrigger deps={[]} />
 </TimeScale>
```

## Changes made

<!-- Provide a detailed description of the changes introduced in this PR -->

- Added `TimeScaleFitContentTrigger` component
- Updated examples to fit content on initial page render

## Related Issues

<!-- Mention the issues that are being closed by this PR -->

Fixes #65 
