### PR TITLE
test: add watermark unit tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import pluginImport from "eslint-plugin-import";
 import pluginJsdoc from "eslint-plugin-jsdoc";
 import pluginReact from "eslint-plugin-react";
 import pluginReactHooks from "eslint-plugin-react-hooks";
+import vitest from "eslint-plugin-vitest";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 
@@ -117,6 +118,32 @@ export default [
       "jsdoc/empty-tags": "warn",
       "jsdoc/require-param": "warn",
       "jsdoc/require-returns": "warn",
+    },
+  },
+  {
+    files: ["lib/src/**/*.test.ts", "lib/src/**/*.test.tsx"],
+    plugins: {
+      vitest,
+    },
+    languageOptions: {
+      globals: {
+        ...vitest.environments.env.globals,
+      },
+    },
+    rules: {
+      ...vitest.configs.recommended.rules,
+      "vitest/max-nested-describe": [
+        "error",
+        {
+          max: 3,
+        },
+      ],
+      "vitest/prefer-lowercase-title": [
+        "error",
+        {
+          ignore: ["describe"],
+        },
+      ],
     },
   },
 ];

--- a/lib/src/watermark/Watermark.test.tsx
+++ b/lib/src/watermark/Watermark.test.tsx
@@ -1,0 +1,44 @@
+import { render } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as useWatermarkModule from "./useWatermark";
+import { WatermarkText, WatermarkImage } from "./Watermark";
+import type { WatermarkApiRef } from "./types";
+
+vi.mock("./useWatermark");
+
+describe("Watermark components", () => {
+  const mockApiRef = {
+    api: vi.fn(),
+    init: vi.fn(),
+    clear: vi.fn(),
+    _watermark: null,
+  };
+
+  beforeEach(() => {
+    vi.mocked(useWatermarkModule.useWatermark).mockReturnValue({
+      current: mockApiRef,
+    });
+  });
+
+  it("forwards ref in WatermarkText", () => {
+    const ref = createRef<WatermarkApiRef<"text">>();
+    render(<WatermarkText ref={ref} lines={[{ text: "Test", fontSize: 20 }]} />);
+
+    expect(ref.current).toBe(mockApiRef);
+  });
+
+  it("forwards ref in WatermarkImage", () => {
+    const ref = createRef<WatermarkApiRef<"image">>();
+    render(<WatermarkImage ref={ref} src="src" />);
+
+    expect(ref.current).toBe(mockApiRef);
+  });
+
+  it("does not render anything to the DOM", () => {
+    const { container } = render(
+      <WatermarkText ref={createRef()} lines={[{ text: "Test", fontSize: 20 }]} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/lib/src/watermark/useWatermark.test.tsx
+++ b/lib/src/watermark/useWatermark.test.tsx
@@ -1,5 +1,103 @@
-import { describe, it } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { createImageWatermark, createTextWatermark } from "lightweight-charts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSafeContext } from "@/_shared/useSafeContext";
+import { useWatermark } from "./useWatermark";
+
+vi.mock("@/_shared/useSafeContext");
+vi.mock("lightweight-charts");
+
+const mockDetach = vi.fn();
+const mockApplyOptions = vi.fn();
+const mockGetPane = vi.fn();
+
+const mockChart = {
+  api: () => ({
+    panes: () => [{}],
+  }),
+};
 
 describe("useWatermark", () => {
-  it("should create a text watermark", () => {});
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("initializes text watermark", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: true,
+      chartApiRef: mockChart,
+    });
+    vi.mocked(createTextWatermark).mockReturnValue({
+      detach: mockDetach,
+      applyOptions: mockApplyOptions,
+      getPane: mockGetPane,
+    });
+
+    const { result } = renderHook(() =>
+      useWatermark({
+        type: "text",
+        lines: [
+          {
+            text: "Test Watermark",
+            fontSize: 20,
+          },
+        ],
+      })
+    );
+
+    const api = result.current.current.api();
+    expect(api).toBeDefined();
+    expect(createTextWatermark).toHaveBeenCalled();
+  });
+
+  it("initializes image watermark", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: true,
+      chartApiRef: mockChart,
+    });
+
+    vi.mocked(createImageWatermark).mockReturnValue({
+      detach: mockDetach,
+      applyOptions: mockApplyOptions,
+      getPane: mockGetPane,
+    });
+
+    const { result } = renderHook(() =>
+      useWatermark({
+        type: "image",
+        src: "src",
+      })
+    );
+
+    const api = result.current.current.api();
+    expect(api).toBeDefined();
+    expect(createImageWatermark).toHaveBeenCalled();
+  });
+
+  it("clears watermark on unmount", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: true,
+      chartApiRef: mockChart,
+    });
+    vi.mocked(createTextWatermark).mockReturnValue({
+      detach: mockDetach,
+      applyOptions: mockApplyOptions,
+      getPane: mockGetPane,
+    });
+
+    const { unmount } = renderHook(() =>
+      useWatermark({
+        type: "text",
+        lines: [
+          {
+            text: "Test Watermark",
+            fontSize: 20,
+          },
+        ],
+      })
+    );
+
+    unmount();
+    expect(mockDetach).toHaveBeenCalled();
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint-plugin-jsdoc": "^50.6.9",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-vitest": "^0.5.4",
         "globals": "^16.0.0",
         "jsdom": "^26.1.0",
         "knip": "^5.46.5",
@@ -4314,6 +4315,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/array.prototype.findlast": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
@@ -5317,6 +5327,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -6010,6 +6032,175 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-vitest": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vitest/-/eslint-plugin-vitest-0.5.4.tgz",
+      "integrity": "sha512-um+odCkccAHU53WdKAw39MY61+1x990uXjSPguUCq3VcEHdqJrOb8OTMrbYlY6f9jAKx7x98kLVlIe3RJeJqoQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^7.7.1"
+      },
+      "engines": {
+        "node": "^18.0.0 || >= 20.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/types": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/eslint-plugin-vitest/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-vitest/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-vitest/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-vitest/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-vitest/node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -6773,6 +6964,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globrex": {
@@ -9420,6 +9631,15 @@
       "hasInstallScript": true,
       "bin": {
         "simple-git-hooks": "cli.js"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/slashes": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-jsdoc": "^50.6.9",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-vitest": "^0.5.4",
     "globals": "^16.0.0",
     "jsdom": "^26.1.0",
     "knip": "^5.46.5",


### PR DESCRIPTION
## Short Summary

<!-- Provide a brief summary of the changes introduced in this PR -->

This diff adds unit tests for `Watermark` and `useWatermark` hook.

## Changes made

<!-- Provide a detailed description of the changes introduced in this PR -->

- Added unit tests
- Added `eslint-plugin-vitest` and some rules enforced

## Related Issues

<!-- Mention the issues that are being closed by this PR -->

Related to #81 
