### PR TITLE
test: add scales components and hooks tests

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Feat
 - add chart `onDblClick` prop to handle double-click event subscription
+### Fix
+- fix `PriceLine` price property change does not apply to price line on the chart
 
 ## [0.3.4] - 2025-05-09
 ### Fix

--- a/lib/src/_shared/useSafeContext.test.tsx
+++ b/lib/src/_shared/useSafeContext.test.tsx
@@ -1,0 +1,44 @@
+import { renderHook } from "@testing-library/react";
+import { createContext } from "react";
+import { describe, expect, it } from "vitest";
+import { BaseInternalError } from "./InternalError";
+import { useSafeContext } from "./useSafeContext";
+import type { PropsWithChildren } from "react";
+
+describe("useSafeContext", () => {
+  it("returns the context value when context is available", () => {
+    const TestContext = createContext<string | undefined>(undefined);
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <TestContext.Provider value="hello">{children}</TestContext.Provider>
+    );
+
+    const { result } = renderHook(() => useSafeContext(TestContext), { wrapper });
+
+    expect(result.current).toBe("hello");
+  });
+
+  it("throws BaseInternalError if context is undefined", () => {
+    const TestContext = createContext<string | undefined>(undefined);
+    TestContext.displayName = "TestContext";
+
+    try {
+      renderHook(() => useSafeContext(TestContext));
+    } catch (error) {
+      expect(error).toBeInstanceOf(BaseInternalError);
+      expect((error as BaseInternalError).message).toContain("not found");
+      expect((error as BaseInternalError).message).toContain("TestContext");
+    }
+  });
+
+  it("throws BaseInternalError with custom error message", () => {
+    const TestContext = createContext<string | undefined>(undefined);
+
+    try {
+      renderHook(() => useSafeContext(TestContext, "Custom error message"));
+    } catch (error) {
+      expect(error).toBeInstanceOf(BaseInternalError);
+      expect((error as BaseInternalError).message).toContain("Custom error message");
+    }
+  });
+});

--- a/lib/src/_shared/useSafeContext.ts
+++ b/lib/src/_shared/useSafeContext.ts
@@ -5,7 +5,7 @@ export const useSafeContext = <T>(context: Context<T>, errorMessage?: string) =>
   const currentContextValue = useContext(context);
 
   if (!currentContextValue) {
-    const ctxName = context.name;
+    const ctxName = context.name ?? context.displayName ?? "Context";
     throw new BaseInternalError(errorMessage ?? `${ctxName} not found.`, {
       isOperational: true,
     });

--- a/lib/src/priceLine/usePriceLine.ts
+++ b/lib/src/priceLine/usePriceLine.ts
@@ -55,5 +55,13 @@ export const usePriceLine = ({ options, price }: PriceLineProps) => {
     }
   }, [options]);
 
+  useLayoutEffect(() => {
+    if (!series) return;
+
+    if (price) {
+      priceLineApiRef.current.api()?.applyOptions({ price });
+    }
+  }, [price]);
+
   return priceLineApiRef;
 };

--- a/lib/src/scales/PriceScale.test.tsx
+++ b/lib/src/scales/PriceScale.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PriceScale } from "./PriceScale";
+import { usePriceScale } from "./usePriceScale";
+import type { PriceScaleApiRef } from "./types";
+
+vi.mock("./usePriceScale");
+
+const mockApiRef = {
+  api: vi.fn(),
+  init: vi.fn(),
+  clear: vi.fn(),
+  _priceScale: null,
+  setId: vi.fn(),
+};
+
+vi.mocked(usePriceScale).mockReturnValue({
+  current: mockApiRef,
+});
+
+describe("PriceScale component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards ref in PriceLine", () => {
+    const ref = createRef<PriceScaleApiRef>();
+    render(<PriceScale ref={ref} id="left" />);
+    expect(ref.current).toBe(mockApiRef);
+  });
+
+  it("does not render anything to the DOM", () => {
+    const { container } = render(
+      <PriceScale ref={createRef<PriceScaleApiRef>()} id="left" />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/lib/src/scales/TimeScale.test.tsx
+++ b/lib/src/scales/TimeScale.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TimeScale } from "./TimeScale";
+import { useTimeScale } from "./useTimeScale";
+import type { TimeScaleApiRef } from "./types";
+
+vi.mock("./useTimeScale");
+
+const mockApiRef = {
+  api: vi.fn(),
+  init: vi.fn(),
+  clear: vi.fn(),
+  _timeScale: null,
+};
+
+vi.mocked(useTimeScale).mockReturnValue({
+  timeScaleApiRef: {
+    current: mockApiRef,
+  },
+  isReady: true,
+});
+
+describe("TimeScale component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards ref in TimeScale", () => {
+    const ref = createRef<TimeScaleApiRef>();
+    render(<TimeScale ref={ref} />);
+    expect(ref.current).toBe(mockApiRef);
+  });
+
+  it("does not render anything to the DOM", () => {
+    const { container } = render(<TimeScale ref={createRef<TimeScaleApiRef>()} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/lib/src/scales/TimeScaleFitContentTrigger.test.tsx
+++ b/lib/src/scales/TimeScaleFitContentTrigger.test.tsx
@@ -1,0 +1,23 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TimeScaleFitContentTrigger } from "./TimeScaleFitContentTrigger";
+import { useTimeScaleFitContentTrigger } from "./useTimeScaleFitContentTrigger";
+
+vi.mock("./useTimeScaleFitContentTrigger");
+
+describe("TimeScaleFitContentTrigger component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not render anything to the DOM", () => {
+    const { container } = render(<TimeScaleFitContentTrigger deps={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("calls useTimeScaleFitContentTrigger with the correct props", () => {
+    const deps = [1, 2, 3];
+    render(<TimeScaleFitContentTrigger deps={deps} />);
+    expect(useTimeScaleFitContentTrigger).toHaveBeenCalledWith({ deps });
+  });
+});

--- a/lib/src/scales/usePriceScale.test.tsx
+++ b/lib/src/scales/usePriceScale.test.tsx
@@ -1,0 +1,91 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSafeContext } from "@/_shared/useSafeContext";
+import { usePriceScale } from "./usePriceScale";
+
+vi.mock("@/_shared/useSafeContext");
+
+const mockApplyOptions = vi.fn();
+
+const mockChart = {
+  api: () => ({
+    priceScale: vi.fn().mockReturnValue({
+      applyOptions: mockApplyOptions,
+      options: vi.fn(),
+      width: vi.fn(),
+    }),
+  }),
+};
+
+describe("usePriceScale", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("initializes priceScale", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: true,
+      chartApiRef: mockChart,
+    });
+
+    const { result } = renderHook(() =>
+      usePriceScale({
+        id: "right",
+      })
+    );
+
+    const api = result.current.current.api();
+    expect(api).toBeDefined();
+  });
+
+  it("applies options to priceScale", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: true,
+      chartApiRef: mockChart,
+    });
+
+    const { rerender } = renderHook(
+      props =>
+        usePriceScale({
+          id: "right",
+          options: props.options,
+        }),
+      {
+        initialProps: {
+          options: {
+            autoScale: true,
+          },
+        },
+      }
+    );
+
+    expect(mockApplyOptions).toHaveBeenCalledWith({
+      autoScale: true,
+    });
+
+    rerender({
+      options: {
+        autoScale: false,
+      },
+    });
+
+    expect(mockApplyOptions).toHaveBeenCalledWith({
+      autoScale: false,
+    });
+  });
+
+  it("does not initialize priceScale if not ready", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: false,
+      chartApiRef: mockChart,
+    });
+
+    const { result } = renderHook(() =>
+      usePriceScale({
+        id: "right",
+      })
+    );
+
+    expect(result.current.current.api()).toBeNull();
+  });
+});

--- a/lib/src/scales/useTimeScale.test.tsx
+++ b/lib/src/scales/useTimeScale.test.tsx
@@ -1,0 +1,210 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSafeContext } from "@/_shared/useSafeContext";
+import { useTimeScale } from "./useTimeScale";
+import type { TimeScaleProps } from "./types";
+
+vi.mock("@/_shared/useSafeContext");
+
+const mockApplyOptions = vi.fn();
+const mockSetVisibleRange = vi.fn();
+const mockSetVisibleLogicalRange = vi.fn();
+const mockSubscribeVisibleTimeRangeChange = vi.fn();
+const mockSubscribeVisibleLogicalRangeChange = vi.fn();
+const mockSubscribeSizeChange = vi.fn();
+
+const mockChart = {
+  api: () => ({
+    timeScale: vi.fn().mockReturnValue({
+      applyOptions: mockApplyOptions,
+      setVisibleRange: mockSetVisibleRange,
+      setVisibleLogicalRange: mockSetVisibleLogicalRange,
+      subscribeVisibleTimeRangeChange: mockSubscribeVisibleTimeRangeChange,
+      subscribeVisibleLogicalRangeChange: mockSubscribeVisibleLogicalRangeChange,
+      subscribeSizeChange: mockSubscribeSizeChange,
+    }),
+  }),
+};
+
+describe("useTimeScale", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("initializes timeScale", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: true,
+      chartApiRef: mockChart,
+    });
+
+    const { result } = renderHook(() => useTimeScale({}));
+
+    const api = result.current.timeScaleApiRef.current.api();
+    expect(api).toBeDefined();
+  });
+
+  it("applies options to timeScale", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: true,
+      chartApiRef: mockChart,
+    });
+
+    const { rerender } = renderHook(
+      props =>
+        useTimeScale({
+          options: props.options,
+        }),
+      {
+        initialProps: {
+          options: {
+            rightOffset: 1,
+          },
+        } as TimeScaleProps,
+      }
+    );
+
+    expect(mockApplyOptions).toHaveBeenCalledWith({
+      rightOffset: 1,
+    });
+
+    rerender({
+      options: {
+        rightOffset: 2,
+      },
+    });
+
+    expect(mockApplyOptions).toHaveBeenCalledWith({
+      rightOffset: 2,
+    });
+  });
+
+  it("sets visible range", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: true,
+      chartApiRef: mockChart,
+    });
+
+    const { rerender } = renderHook(
+      props =>
+        useTimeScale({
+          visibleRange: props.visibleRange,
+        }),
+      {
+        initialProps: {} as TimeScaleProps,
+      }
+    );
+
+    rerender({
+      visibleRange: {
+        from: "2025-05-19",
+        to: "2025-05-20",
+      },
+    });
+
+    expect(mockSetVisibleRange).toHaveBeenCalledWith({
+      from: "2025-05-19",
+      to: "2025-05-20",
+    });
+  });
+
+  it("sets visible logical range", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: true,
+      chartApiRef: mockChart,
+    });
+
+    const { rerender } = renderHook(
+      props =>
+        useTimeScale({
+          visibleLogicalRange: props.visibleLogicalRange,
+        }),
+      {
+        initialProps: {} as TimeScaleProps,
+      }
+    );
+
+    rerender({
+      visibleLogicalRange: {
+        from: 1,
+        to: 2,
+      },
+    });
+
+    expect(mockSetVisibleLogicalRange).toHaveBeenCalledWith({
+      from: 1,
+      to: 2,
+    });
+  });
+
+  it("subscribes to visible time range change", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: true,
+      chartApiRef: mockChart,
+    });
+
+    const { rerender } = renderHook(
+      props =>
+        useTimeScale({
+          onVisibleTimeRangeChange: props.onVisibleTimeRangeChange,
+        }),
+      {
+        initialProps: {} as TimeScaleProps,
+      }
+    );
+
+    const callback = vi.fn();
+    rerender({
+      onVisibleTimeRangeChange: callback,
+    });
+
+    expect(mockSubscribeVisibleTimeRangeChange).toHaveBeenCalledWith(callback);
+  });
+
+  it("subscribes to visible logical range change", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: true,
+      chartApiRef: mockChart,
+    });
+
+    const { rerender } = renderHook(
+      props =>
+        useTimeScale({
+          onVisibleLogicalRangeChange: props.onVisibleLogicalRangeChange,
+        }),
+      {
+        initialProps: {} as TimeScaleProps,
+      }
+    );
+
+    const callback = vi.fn();
+    rerender({
+      onVisibleLogicalRangeChange: callback,
+    });
+
+    expect(mockSubscribeVisibleLogicalRangeChange).toHaveBeenCalledWith(callback);
+  });
+
+  it("subscribes to size change", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: true,
+      chartApiRef: mockChart,
+    });
+
+    const { rerender } = renderHook(
+      props =>
+        useTimeScale({
+          onSizeChange: props.onSizeChange,
+        }),
+      {
+        initialProps: {} as TimeScaleProps,
+      }
+    );
+
+    const callback = vi.fn();
+    rerender({
+      onSizeChange: callback,
+    });
+
+    expect(mockSubscribeSizeChange).toHaveBeenCalledWith(callback);
+  });
+});

--- a/lib/src/scales/useTimeScaleFitContentTrigger.test.tsx
+++ b/lib/src/scales/useTimeScaleFitContentTrigger.test.tsx
@@ -1,0 +1,92 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSafeContext } from "@/_shared/useSafeContext";
+import { useTimeScaleFitContentTrigger } from "./useTimeScaleFitContentTrigger";
+
+vi.mock("@/_shared/useSafeContext");
+
+const mockFitContent = vi.fn();
+
+const mockTimeScale = {
+  api: () => ({
+    fitContent: mockFitContent,
+  }),
+};
+
+describe("useTimeScaleFitContentTrigger", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls fitContent once on render", async () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: true,
+      timeScaleApiRef: mockTimeScale,
+    });
+
+    renderHook(() =>
+      useTimeScaleFitContentTrigger({
+        deps: [],
+      })
+    );
+
+    await Promise.resolve();
+    expect(mockFitContent).toHaveBeenCalled();
+  });
+
+  it("calls fitContent when deps change", async () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: true,
+      timeScaleApiRef: mockTimeScale,
+    });
+
+    const { rerender } = renderHook(
+      props =>
+        useTimeScaleFitContentTrigger({
+          deps: props.deps,
+        }),
+      {
+        initialProps: {
+          deps: [1],
+        },
+      }
+    );
+
+    await Promise.resolve();
+    expect(mockFitContent).toHaveBeenCalledTimes(1);
+
+    rerender({ deps: [2] });
+    await Promise.resolve();
+    expect(mockFitContent).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not call fitContent if isReady is false", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: false,
+      timeScaleApiRef: mockTimeScale,
+    });
+
+    renderHook(() =>
+      useTimeScaleFitContentTrigger({
+        deps: [],
+      })
+    );
+
+    expect(mockFitContent).not.toHaveBeenCalled();
+  });
+
+  it("does not call fitContent if timeScaleApiRef is undefined", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: true,
+      timeScaleApiRef: undefined,
+    });
+
+    renderHook(() =>
+      useTimeScaleFitContentTrigger({
+        deps: [],
+      })
+    );
+
+    expect(mockFitContent).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Short Summary

<!-- Provide a brief summary of the changes introduced in this PR -->

This diff adds unit tests for `PriceScale`, `TimeScale` and `TimeScaleFitContentTrigger` and fixes the `PriceScale` `price` prop issue of not being reactive.

## Changes made

<!-- Provide a detailed description of the changes introduced in this PR -->

- adds unit tests for scales components and hooks
- adds unit tests for `useSafeContext()`
- fixes price scale `price` prop

## Related Issues

<!-- Mention the issues that are being closed by this PR -->

Related to #81 
