### PR TITLE
test: exclude barrel files from coverage

### DIFF
--- a/lib/vitest.config.ts
+++ b/lib/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       reporter: ["json", "text", "lcov"],
       include: ["src/**/*.{ts,tsx}"],
       reportsDirectory: "coverage",
+      exclude: ["**/index.{ts,tsx}"],
     },
     setupFiles: ["@testing-library/jest-dom"],
   },


### PR DESCRIPTION
## Short Summary

This diff excludes `index.ts` files from tests coverage code base.

## Related Issues

<!-- Mention the issues that are being closed by this PR -->

Related to #81 
