### PR TITLE
feat: add series primitive component

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -25,6 +25,7 @@
     "@mui/icons-material": "^6.4.10",
     "@mui/material": "^6.4.7",
     "@react-hook/resize-observer": "^2.0.2",
+    "@uiw/react-color-wheel": "^2.5.5",
     "copy-to-clipboard": "^3.3.3",
     "fancy-canvas": "^2.1.0",
     "lightweight-charts-react-components": "file:../lib",

--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -17,6 +17,7 @@ import { WithLegend } from "./samples/Legend/WithLegend";
 import { Markers } from "./samples/Markers/Markers";
 import { Panes } from "./samples/Panes/Panes";
 import { PriceLines } from "./samples/PriceLines/PriceLines";
+import { Primitives } from "./samples/Primitives/Primitives";
 import { RangeSwitcher } from "./samples/RangeSwitcher/RangeSwitcher";
 import { Scales } from "./samples/Scales/Scales";
 import { Tooltips } from "./samples/Tooltips/Tooltips";
@@ -193,6 +194,7 @@ export const App = () => {
           <Panes />
           <InfiniteData />
           <PriceLines />
+          <Primitives />
         </LayoutGrid>
       </Stack>
       <Footer

--- a/examples/src/common/tooltips.ts
+++ b/examples/src/common/tooltips.ts
@@ -1,0 +1,68 @@
+import type { MouseEventParams } from "lightweight-charts";
+
+type Positioning = "center" | "anchor";
+
+type TooltipOptions = {
+  tooltipWidth: number;
+  tooltipHeight: number;
+  yOffset?: number;
+  xOffset?: number;
+};
+
+const getTooltipPosition = (
+  param: MouseEventParams,
+  containerWidth: number,
+  containerHeight: number,
+  positioning: Positioning,
+  o: TooltipOptions
+) => {
+  const { tooltipHeight, tooltipWidth, yOffset = 10, xOffset = 10 } = o;
+  // const x = param.point!.x + xOffset;
+  // const y = param.point!.y + yOffset;
+  // const xOverflow = x > containerWidth - tooltipWidth;
+  // const yOverflow = y > containerHeight - tooltipHeight;
+
+  // return {
+  //   x: xOverflow ? x - tooltipWidth - xOffset * 2 : x,
+  //   y: yOverflow ? y - tooltipHeight - yOffset * 2 : y,
+  // };
+  const baseX = param.point!.x;
+  const baseY = param.point!.y;
+
+  let x: number;
+  let y: number;
+
+  switch (positioning) {
+    case "center":
+      x = baseX - tooltipWidth / 2;
+      y = baseY - tooltipHeight / 2;
+      break;
+    case "anchor":
+    default:
+      x = baseX + xOffset;
+      y = baseY + yOffset;
+      break;
+  }
+
+  if (x + tooltipWidth > containerWidth) {
+    x =
+      positioning === "center"
+        ? containerWidth - tooltipWidth - xOffset
+        : x - tooltipWidth - xOffset * 2;
+  }
+
+  if (y + tooltipHeight > containerHeight) {
+    y =
+      positioning === "center"
+        ? containerHeight - tooltipHeight - yOffset
+        : y - tooltipHeight - yOffset * 2;
+  }
+
+  // Prevent overflow on left/top
+  if (x < 0) x = xOffset;
+  if (y < 0) y = yOffset;
+
+  return { x, y };
+};
+
+export { getTooltipPosition, type TooltipOptions };

--- a/examples/src/common/utils.ts
+++ b/examples/src/common/utils.ts
@@ -1,3 +1,5 @@
+import { colors } from "@/colors";
+
 const typedObjectKeys = <T extends object>(obj: T): Array<keyof T> => {
   return Object.keys(obj) as Array<keyof T>;
 };
@@ -51,6 +53,18 @@ const deepMergePlainObjects = <
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
+const getContrastingTextColor = (hex: string) => {
+  const cleanHex = hex.replace(/^#/, "");
+
+  const r = parseInt(cleanHex.substring(0, 2), 16);
+  const g = parseInt(cleanHex.substring(2, 4), 16);
+  const b = parseInt(cleanHex.substring(4, 6), 16);
+
+  const luminance = 0.299 * r + 0.587 * g + 0.114 * b;
+
+  return luminance > 150 ? colors.black : colors.white;
+};
+
 export {
   typedObjectKeys,
   createStubArray,
@@ -58,4 +72,5 @@ export {
   typedObjectEntries,
   deepMergePlainObjects,
   sleep,
+  getContrastingTextColor,
 };

--- a/examples/src/samples.ts
+++ b/examples/src/samples.ts
@@ -77,6 +77,11 @@ const samplesLinks = {
     codesandbox: "",
     stackblitz: "",
   },
+  Primitives: {
+    github: `${githubSamplesLocation}/Primitives`,
+    codesandbox: "",
+    stackblitz: "",
+  },
 } as const;
 
 export { samplesLinks, type SampleConfig };

--- a/examples/src/samples/CompareSeries/compareSeriesStore.ts
+++ b/examples/src/samples/CompareSeries/compareSeriesStore.ts
@@ -3,7 +3,8 @@ import { LineSeries } from "lightweight-charts-react-components";
 import { create } from "zustand";
 import { colors } from "@/colors";
 import { generateLineData } from "@/common/generateSeriesData";
-import type { SeriesProps, SeriesType } from "lightweight-charts-react-components";
+import type { SeriesType } from "lightweight-charts";
+import type { SeriesProps } from "lightweight-charts-react-components";
 import type { ComponentType } from "react";
 
 type CompareSeriesType = "Asset B" | "SMA 14" | "EMA 14";

--- a/examples/src/samples/Primitives/Primitives.tsx
+++ b/examples/src/samples/Primitives/Primitives.tsx
@@ -1,0 +1,233 @@
+import {
+  Box,
+  Button,
+  ClickAwayListener,
+  FormControl,
+  FormLabel,
+  Grow,
+  MenuItem,
+  Select,
+  Stack,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
+import {
+  Chart,
+  LineSeries,
+  SeriesPrimitive,
+  TimeScale,
+  TimeScaleFitContentTrigger,
+} from "lightweight-charts-react-components";
+import { lazy, memo, useCallback, useRef, useState } from "react";
+import { colors } from "@/colors";
+import { chartCommonOptions } from "@/common/chartCommonOptions";
+import { getContrastingTextColor } from "@/common/utils";
+import { samplesLinks } from "@/samples";
+import { ChartWidgetCard } from "@/ui/ChartWidgetCard";
+import { ScrollableContainer } from "@/ui/ScrollableContainer";
+import { VerticalLine } from "./primitives/VerticalLine";
+import {
+  areaSeries,
+  maxPrimitivesCountOptions,
+  useMaxPrimitivesCountStore,
+  usePrimitivesStore,
+} from "./primitivesStore";
+import { useTooltip } from "./useTooltip";
+import type { VerticalLineOptions } from "./primitives/VerticalLine";
+import type { PrimitiveData } from "./primitivesStore";
+import type { Time } from "lightweight-charts";
+import type { RenderPrimitive } from "lightweight-charts-react-components";
+
+type VerticalLinePrimitiveProps = {
+  time: Time;
+  options?: Partial<VerticalLineOptions>;
+};
+
+type TooltipProps = {
+  show: boolean;
+  x: number | null;
+  y: number | null;
+  width?: number;
+  height?: number;
+  time: Time | null;
+  onAddPrimitive?: (p: PrimitiveData) => void;
+  onClose?: () => void;
+};
+
+const Wheel = lazy(() => import("@uiw/react-color-wheel"));
+
+const VerticalLinePrimitive = ({ time, options }: VerticalLinePrimitiveProps) => {
+  const renderVertLine: RenderPrimitive = useCallback(
+    ({ chart }) => new VerticalLine({ chart, time, options }),
+    [time, options]
+  );
+  return <SeriesPrimitive render={renderVertLine} />;
+};
+
+const MemoizedVerticalLinePrimitive = memo(VerticalLinePrimitive);
+
+const Tooltip = ({
+  show,
+  x,
+  y,
+  width = 200,
+  height = 200,
+  onAddPrimitive,
+  onClose,
+  time,
+}: TooltipProps) => {
+  const [color, setColor] = useState<string>(colors.pink);
+  const colorPickerSize = width / 1.618;
+
+  return (
+    <Grow in={show} timeout={{ enter: 300 }}>
+      <Box
+        role="tooltip"
+        aria-live="polite"
+        aria-atomic="true"
+        aria-label="Color Picker tooltip"
+        sx={{
+          width: width,
+          height: height,
+          position: "absolute",
+          display: x !== null && y !== null ? "flex" : "none",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          alignItems: "center",
+          borderRadius: 4,
+          padding: 2,
+          boxShadow: 2,
+          backgroundColor: `${colors.black}99`,
+          zIndex: 10,
+          top: y,
+          left: x,
+        }}
+      >
+        <Stack alignItems="center">
+          <Typography color="primary">{`Time: ${time}`}</Typography>
+          <Typography color="info">Choose color:</Typography>
+        </Stack>
+        <Wheel
+          width={colorPickerSize}
+          height={colorPickerSize}
+          color={color}
+          onChange={color => {
+            setColor(color.hex);
+          }}
+        />
+        <Button
+          onClick={() => {
+            onAddPrimitive &&
+              onAddPrimitive({
+                uid: crypto.randomUUID(),
+                time: time as Time,
+                options: {
+                  color,
+                  width: 2,
+                  labelBgColor: color,
+                  labelTextColor: getContrastingTextColor(color),
+                },
+              });
+            onClose && onClose();
+          }}
+          variant="outlined"
+        >
+          Add
+        </Button>
+      </Box>
+    </Grow>
+  );
+};
+
+const Primitives = () => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { maxPrimitivesCount, setMaxPrimitivesCount } = useMaxPrimitivesCountStore();
+  const { primitives, pushPrimitive } = usePrimitivesStore();
+  const tooltipWidth = isMobile ? 175 : 200;
+  const tooltipHeight = tooltipWidth * 1.618;
+  const {
+    close,
+    position: { x, y },
+    show,
+    onChartClick,
+    time,
+  } = useTooltip({
+    width: tooltipWidth,
+    height: tooltipHeight,
+    containerRef,
+  });
+
+  return (
+    <ChartWidgetCard
+      title="Primitives"
+      subTitle="Multiple primitives display on the chart. Click on the chart to add a vertical line."
+      sampleConfig={samplesLinks.Primitives}
+    >
+      <ScrollableContainer sx={{ marginBottom: 2 }}>
+        <FormControl sx={{ flexDirection: "row", alignItems: "center" }}>
+          <FormLabel htmlFor="max-primitives-count" sx={{ marginRight: 1 }}>
+            Max. primitives count:
+          </FormLabel>
+          <Select
+            value={maxPrimitivesCount}
+            onChange={({ target }) => setMaxPrimitivesCount(target.value as number)}
+            size="small"
+            variant="outlined"
+            sx={{ minWidth: 120 }}
+            inputProps={{ "aria-label": "Max. primitives count" }}
+            id="max-primitives-count"
+          >
+            {maxPrimitivesCountOptions.map(({ value, label }) => (
+              <MenuItem key={label} value={value}>
+                {label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </ScrollableContainer>
+      <ClickAwayListener onClickAway={close}>
+        <Box sx={{ flexGrow: 1, position: "relative" }} role="presentation">
+          <Chart
+            options={chartCommonOptions}
+            containerProps={{
+              style: { height: "100%" },
+            }}
+            ref={containerRef}
+            onClick={onChartClick}
+          >
+            <LineSeries
+              data={areaSeries}
+              options={{
+                lineWidth: 3,
+                color: colors.violet,
+                priceLineVisible: false,
+              }}
+            >
+              {primitives.map(({ uid, options, time }) => (
+                <MemoizedVerticalLinePrimitive key={uid} time={time} options={options} />
+              ))}
+            </LineSeries>
+            <TimeScale onVisibleTimeRangeChange={close}>
+              <TimeScaleFitContentTrigger deps={[]} />
+            </TimeScale>
+            <Tooltip
+              show={show}
+              x={x}
+              y={y}
+              time={time}
+              onClose={close}
+              onAddPrimitive={pushPrimitive}
+              width={tooltipWidth}
+              height={tooltipHeight}
+            />
+          </Chart>
+        </Box>
+      </ClickAwayListener>
+    </ChartWidgetCard>
+  );
+};
+
+export { Primitives };

--- a/examples/src/samples/Primitives/primitives/VerticalLine.ts
+++ b/examples/src/samples/Primitives/primitives/VerticalLine.ts
@@ -1,0 +1,136 @@
+import { colors } from "@/colors";
+import type { CanvasRenderingTarget2D } from "fancy-canvas";
+import type {
+  Coordinate,
+  IChartApi,
+  IPrimitivePaneRenderer,
+  IPrimitivePaneView,
+  ISeriesPrimitive,
+  ISeriesPrimitiveAxisView,
+  Time,
+} from "lightweight-charts";
+
+type VerticalLineOptions = {
+  color: string;
+  width: number;
+  labelBgColor: string;
+  labelTextColor: string;
+};
+
+type VerticalLineParams = {
+  time: Time;
+  chart: IChartApi;
+  options?: Partial<VerticalLineOptions>;
+};
+
+const defaultVerticalLineOptions: VerticalLineOptions = {
+  color: colors.red,
+  width: 1,
+  labelBgColor: colors.red,
+  labelTextColor: colors.white,
+};
+
+class VerticalLineRenderer implements IPrimitivePaneRenderer {
+  constructor(
+    private options: VerticalLineOptions,
+    private x: Coordinate | null
+  ) {}
+
+  draw(target: CanvasRenderingTarget2D) {
+    const { width, color } = this.options;
+
+    target.useBitmapCoordinateSpace(scope => {
+      if (this.x === null) {
+        return;
+      }
+
+      const ctx = scope.context;
+      const scaledPosition = Math.round(scope.horizontalPixelRatio * this.x);
+      const lineWidthInPixels = Math.round(width * scope.horizontalPixelRatio);
+      const halfWidth = scaledPosition - (lineWidthInPixels >> 1);
+
+      ctx.fillStyle = color;
+      ctx.fillRect(halfWidth, 0, lineWidthInPixels, scope.bitmapSize.height);
+    });
+  }
+}
+
+class VerticalLinePaneView implements IPrimitivePaneView {
+  private x: Coordinate | null = null;
+
+  constructor(private primitive: VerticalLine) {}
+
+  renderer() {
+    return new VerticalLineRenderer(this.primitive.options, this.x);
+  }
+
+  update() {
+    const timeScale = this.primitive.chart.timeScale();
+    this.x = timeScale.timeToCoordinate(this.primitive.time);
+  }
+}
+
+class VerticalLineAxisView implements ISeriesPrimitiveAxisView {
+  private x: Coordinate | null = null;
+
+  constructor(private primitive: VerticalLine) {}
+
+  update() {
+    const timeScale = this.primitive.chart.timeScale();
+    this.x = timeScale.timeToCoordinate(this.primitive.time);
+  }
+
+  coordinate() {
+    return this.x ?? 0;
+  }
+
+  text() {
+    return this.primitive.time.toString();
+  }
+
+  textColor() {
+    return this.primitive.options.labelTextColor;
+  }
+
+  backColor() {
+    return this.primitive.options.labelBgColor;
+  }
+
+  tickVisible() {
+    return false;
+  }
+}
+
+class VerticalLine implements ISeriesPrimitive<Time> {
+  private _paneViews: VerticalLinePaneView[];
+  private _timeAxisViews: VerticalLineAxisView[];
+
+  time: Time;
+  chart: IChartApi;
+  options: VerticalLineOptions;
+
+  constructor({ chart, time, options }: VerticalLineParams) {
+    this.time = time;
+    this.chart = chart;
+
+    this.options = { ...defaultVerticalLineOptions, ...options };
+
+    this._paneViews = [new VerticalLinePaneView(this)];
+    this._timeAxisViews = [new VerticalLineAxisView(this)];
+  }
+
+  updateAllViews(): void {
+    this._paneViews.forEach(pw => pw.update());
+    this._timeAxisViews.forEach(tw => tw.update());
+  }
+
+  timeAxisViews() {
+    return this._timeAxisViews;
+  }
+
+  paneViews() {
+    return this._paneViews;
+  }
+}
+
+export { VerticalLine, type VerticalLineOptions };

--- a/examples/src/samples/Primitives/primitivesStore.ts
+++ b/examples/src/samples/Primitives/primitivesStore.ts
@@ -1,0 +1,81 @@
+import { create } from "zustand";
+import { generateLineData } from "@/common/generateSeriesData";
+import type { VerticalLineOptions } from "./primitives/VerticalLine";
+import type { Time } from "lightweight-charts";
+
+type PrimitiveData = {
+  time: Time;
+  uid: string;
+  options?: Partial<VerticalLineOptions>;
+};
+
+interface MaxPrimitivesCountStore {
+  maxPrimitivesCount: number;
+  setMaxPrimitivesCount: (v: number) => void;
+}
+
+interface PrimitivesStore {
+  primitives: PrimitiveData[];
+  pushPrimitive: (primitive: PrimitiveData) => void;
+  shiftPrimitives: (count: number) => void;
+}
+
+const areaSeries = generateLineData(50);
+
+const maxPrimitivesCountOptions = [
+  { value: 1, label: "1" },
+  { value: 3, label: "3" },
+  { value: 5, label: "5" },
+] as const;
+
+const useMaxPrimitivesCountStore = create<MaxPrimitivesCountStore>(set => ({
+  maxPrimitivesCount: 3,
+  setMaxPrimitivesCount: (v: number) => set(() => ({ maxPrimitivesCount: v })),
+}));
+
+const usePrimitivesStore = create<PrimitivesStore>(set => ({
+  primitives: [],
+  pushPrimitive: primitive =>
+    set(state => {
+      const { primitives } = state;
+      const maxPrimitivesCount = useMaxPrimitivesCountStore.getState().maxPrimitivesCount;
+
+      const newPrimitives = primitives
+        .slice(primitives.length >= maxPrimitivesCount ? 1 : 0)
+        .concat(primitive);
+
+      return { primitives: newPrimitives };
+    }),
+  shiftPrimitives: count =>
+    set(state => {
+      const { primitives } = state;
+      const newPrimitives = [...primitives];
+      const primitivesToRemove = count;
+
+      if (primitivesToRemove >= newPrimitives.length) {
+        newPrimitives.length = 0;
+      } else {
+        newPrimitives.splice(0, primitivesToRemove);
+      }
+
+      return { primitives: newPrimitives };
+    }),
+}));
+
+useMaxPrimitivesCountStore.subscribe(state => {
+  const { maxPrimitivesCount } = state;
+  const { primitives, shiftPrimitives } = usePrimitivesStore.getState();
+
+  if (primitives.length > maxPrimitivesCount) {
+    const excessCount = primitives.length - maxPrimitivesCount;
+    shiftPrimitives(excessCount);
+  }
+});
+
+export {
+  areaSeries,
+  useMaxPrimitivesCountStore,
+  maxPrimitivesCountOptions,
+  usePrimitivesStore,
+  type PrimitiveData,
+};

--- a/examples/src/samples/Primitives/useTooltip.ts
+++ b/examples/src/samples/Primitives/useTooltip.ts
@@ -1,0 +1,73 @@
+import { useCallback, useState } from "react";
+import { getTooltipPosition } from "@/common/tooltips";
+import { useSize } from "@/common/useSize";
+import type { MouseEventHandler, Time } from "lightweight-charts";
+import type { RefObject } from "react";
+
+type Position = {
+  x: number | null;
+  y: number | null;
+};
+
+type UseTooltipParams = {
+  width: number;
+  height: number;
+  containerRef: RefObject<HTMLElement | null>;
+};
+
+const tooltipOffset = 10;
+
+const useTooltip = ({ width, height, containerRef }: UseTooltipParams) => {
+  const size = useSize(containerRef);
+  const containerWidth = size?.width;
+  const containerHeight = size?.height;
+  const [position, setPosition] = useState<Position>({
+    x: null,
+    y: null,
+  });
+  const [_show, setShow] = useState<boolean>(false);
+  const [time, setTime] = useState<Time | null>(null);
+  const close = useCallback(() => {
+    setShow(false);
+    setPosition({
+      x: null,
+      y: null,
+    });
+  }, []);
+  const show = _show && time !== null && position.x !== null && position.y !== null;
+
+  const onChartClick: MouseEventHandler<Time> = useCallback(
+    param => {
+      if (!containerWidth || !containerHeight) {
+        return;
+      }
+
+      const time = param.time;
+      if (time === undefined || param.point === undefined) {
+        return;
+      }
+
+      const tooltipPos = getTooltipPosition(
+        param,
+        containerWidth,
+        containerHeight,
+        "center",
+        {
+          tooltipWidth: width,
+          tooltipHeight: height,
+          xOffset: tooltipOffset,
+          yOffset: tooltipOffset,
+        }
+      );
+
+      setPosition(tooltipPos);
+      setShow(true);
+      setTime(time);
+    },
+    [containerWidth, containerHeight, width, height]
+  );
+
+  return { position, show, close, onChartClick, time };
+};
+
+export { useTooltip };

--- a/examples/src/samples/Tooltips/hooks.ts
+++ b/examples/src/samples/Tooltips/hooks.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from "react";
+import { getTooltipPosition, type TooltipOptions } from "@/common/tooltips";
 import { useSize } from "@/common/useSize";
 import type {
   LineData,
@@ -29,31 +30,6 @@ type MultipleSeriesTooltipData = {
   };
 };
 
-type Options = {
-  tooltipWidth: number;
-  tooltipHeight: number;
-  yOffset?: number;
-  xOffset?: number;
-};
-
-const getTooltipPosition = (
-  param: MouseEventParams,
-  containerWidth: number,
-  containerHeight: number,
-  o: Options
-) => {
-  const { tooltipHeight, tooltipWidth, yOffset = 10, xOffset = 10 } = o;
-  const x = param.point!.x + xOffset;
-  const y = param.point!.y + yOffset;
-  const xOverflow = x > containerWidth - tooltipWidth;
-  const yOverflow = y > containerHeight - tooltipHeight;
-
-  return {
-    x: xOverflow ? x - tooltipWidth - xOffset * 2 : x,
-    y: yOverflow ? y - tooltipHeight - yOffset * 2 : y,
-  };
-};
-
 const getShowTooltip = (param: MouseEventParams) => {
   return (
     param.time !== undefined &&
@@ -65,7 +41,7 @@ const getShowTooltip = (param: MouseEventParams) => {
 
 const useBasicTooltip = (
   containerRef: RefObject<HTMLElement | null>,
-  options: Options
+  options: TooltipOptions
 ) => {
   const seriesRef = useRef<SeriesApiRef<"Line">>(null);
   const size = useSize(containerRef);
@@ -119,6 +95,7 @@ const useBasicTooltip = (
                 param,
                 containerWidth,
                 containerHeight,
+                "anchor",
                 options
               ),
             }
@@ -138,7 +115,7 @@ const useBasicTooltip = (
 const useMultipleSeriesTooltip = (
   containerRef: RefObject<HTMLElement | null>,
   seriesRefs: Array<RefObject<SeriesApiRef<"Line"> | null>>,
-  options: Options
+  options: TooltipOptions
 ) => {
   const size = useSize(containerRef);
   const containerWidth = size?.width;
@@ -197,6 +174,7 @@ const useMultipleSeriesTooltip = (
                 param,
                 containerWidth,
                 containerHeight,
+                "anchor",
                 options
               ),
             }

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Feat
+- add `SeriesPrimitive` component
 
 ## [0.3.5] - 2025-05-19
 ### Feat

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Feat
+### Added
 - add `SeriesPrimitive` component
+### Changed
+- custom `SeriesType` is replaced with lightweight-charts `SeriesType`
 
 ## [0.3.5] - 2025-05-19
 ### Feat

--- a/lib/package.json
+++ b/lib/package.json
@@ -5,7 +5,7 @@
     "build": "rslib build",
     "dev": "rslib build --watch",
     "test:unit": "vitest",
-    "test:all": "npm run test:unit -- run --coverage",
+    "test:all": "npm run test:unit -- run",
     "check-exports": "attw --pack . --ignore-rules=cjs-resolves-to-esm"
   },
   "description": "React components for Lightweight Charts",

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -4,3 +4,4 @@ export * from "./series";
 export * from "./priceLine";
 export * from "./markers";
 export * from "./watermark";
+export * from "./primitives";

--- a/lib/src/primitives/SeriesPrimitive.test.tsx
+++ b/lib/src/primitives/SeriesPrimitive.test.tsx
@@ -1,0 +1,38 @@
+import { render } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SeriesPrimitive } from "./SeriesPrimitive";
+import { useSeriesPrimitive } from "./useSeriesPrimitive";
+import type { SeriesPrimitiveApiRef } from "./types";
+
+vi.mock("./useSeriesPrimitive");
+
+const mockApiRef = {
+  api: vi.fn(),
+  init: vi.fn(),
+  clear: vi.fn(),
+  _primitive: null,
+};
+
+vi.mocked(useSeriesPrimitive).mockReturnValue({
+  current: mockApiRef,
+});
+
+describe("SeriesPrimitive component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards ref in SeriesPrimitive", () => {
+    const ref = createRef<SeriesPrimitiveApiRef>();
+    render(<SeriesPrimitive ref={ref} plugin={{}} />);
+    expect(ref.current).toBe(mockApiRef);
+  });
+
+  it("does not render anything to the DOM", () => {
+    const { container } = render(
+      <SeriesPrimitive ref={createRef<SeriesPrimitiveApiRef>()} plugin={{}} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/lib/src/primitives/SeriesPrimitive.tsx
+++ b/lib/src/primitives/SeriesPrimitive.tsx
@@ -1,18 +1,29 @@
 import { forwardRef, useImperativeHandle } from "react";
 import { useSeriesPrimitive } from "./useSeriesPrimitive";
 import type { SeriesPrimitiveApiRef, SeriesPrimitiveProps } from "./types";
+import type { SeriesType } from "lightweight-charts";
 import type { ForwardedRef } from "react";
 
-const SeriesPrimitiveRenderFunction = (
-  props: SeriesPrimitiveProps,
+type GenericSeriesPrimitiveComponent = (<T extends SeriesType>(
+  props: SeriesPrimitiveProps<T> & {
+    ref?: ForwardedRef<SeriesPrimitiveApiRef>;
+  }
+) => ReturnType<typeof SeriesPrimitiveRenderFunction>) & {
+  displayName: string;
+};
+
+const SeriesPrimitiveRenderFunction = <T extends SeriesType>(
+  props: SeriesPrimitiveProps<T>,
   ref: ForwardedRef<SeriesPrimitiveApiRef>
 ) => {
-  const priceScaleApiRef = useSeriesPrimitive(props);
-  useImperativeHandle(ref, () => priceScaleApiRef.current, [priceScaleApiRef]);
+  const seriesPrimitiveApiRef = useSeriesPrimitive(props);
+  useImperativeHandle(ref, () => seriesPrimitiveApiRef.current, [seriesPrimitiveApiRef]);
 
   return null;
 };
 
-const SeriesPrimitive = forwardRef(SeriesPrimitiveRenderFunction);
-SeriesPrimitive.displayName = "Primitive";
+const SeriesPrimitive = forwardRef(
+  SeriesPrimitiveRenderFunction
+) as GenericSeriesPrimitiveComponent;
+SeriesPrimitive.displayName = "SeriesPrimitive";
 export { SeriesPrimitive };

--- a/lib/src/primitives/SeriesPrimitive.tsx
+++ b/lib/src/primitives/SeriesPrimitive.tsx
@@ -1,0 +1,18 @@
+import { forwardRef, useImperativeHandle } from "react";
+import { useSeriesPrimitive } from "./useSeriesPrimitive";
+import type { SeriesPrimitiveApiRef, SeriesPrimitiveProps } from "./types";
+import type { ForwardedRef } from "react";
+
+const SeriesPrimitiveRenderFunction = (
+  props: SeriesPrimitiveProps,
+  ref: ForwardedRef<SeriesPrimitiveApiRef>
+) => {
+  const priceScaleApiRef = useSeriesPrimitive(props);
+  useImperativeHandle(ref, () => priceScaleApiRef.current, [priceScaleApiRef]);
+
+  return null;
+};
+
+const SeriesPrimitive = forwardRef(SeriesPrimitiveRenderFunction);
+SeriesPrimitive.displayName = "Primitive";
+export { SeriesPrimitive };

--- a/lib/src/primitives/index.ts
+++ b/lib/src/primitives/index.ts
@@ -1,0 +1,4 @@
+/**
+ * so the primitive can draw on the different places of the chart
+ * pane, series, price pane, time pane, price label, time label
+ */

--- a/lib/src/primitives/index.ts
+++ b/lib/src/primitives/index.ts
@@ -1,4 +1,6 @@
-/**
- * so the primitive can draw on the different places of the chart
- * pane, series, price pane, time pane, price label, time label
- */
+export { SeriesPrimitive } from "./SeriesPrimitive";
+export type {
+  SeriesPrimitiveProps,
+  RenderPrimitive,
+  SeriesPrimitiveApiRef,
+} from "./types";

--- a/lib/src/primitives/types.ts
+++ b/lib/src/primitives/types.ts
@@ -1,8 +1,9 @@
-import type { ISeriesPrimitive } from "lightweight-charts";
-
-export type SeriesPrimitiveProps = {
-  plugin: ISeriesPrimitive;
-};
+import type {
+  IChartApi,
+  ISeriesApi,
+  ISeriesPrimitive,
+  SeriesType,
+} from "lightweight-charts";
 
 export type SeriesPrimitiveApiRef = {
   _primitive: ISeriesPrimitive | null;
@@ -10,3 +11,25 @@ export type SeriesPrimitiveApiRef = {
   init(): ISeriesPrimitive | null;
   clear(): void;
 };
+
+export type RenderPrimitive<T extends SeriesType = SeriesType> = ({
+  chart,
+  series,
+}: {
+  chart: IChartApi;
+  series: ISeriesApi<T>;
+}) => ISeriesPrimitive;
+
+type SeriesPrimitivePropsWithRender<T extends SeriesType> = {
+  render: RenderPrimitive<T>;
+  plugin?: never;
+};
+
+type SeriesPrimitivePropsWithPlugin = {
+  plugin: ISeriesPrimitive;
+  render?: never;
+};
+
+export type SeriesPrimitiveProps<T extends SeriesType = SeriesType> =
+  | SeriesPrimitivePropsWithRender<T>
+  | SeriesPrimitivePropsWithPlugin;

--- a/lib/src/primitives/types.ts
+++ b/lib/src/primitives/types.ts
@@ -1,0 +1,12 @@
+import type { ISeriesPrimitive } from "lightweight-charts";
+
+export type SeriesPrimitiveProps = {
+  plugin: ISeriesPrimitive;
+};
+
+export type SeriesPrimitiveApiRef = {
+  _primitive: ISeriesPrimitive | null;
+  api(): ISeriesPrimitive | null;
+  init(): ISeriesPrimitive | null;
+  clear(): void;
+};

--- a/lib/src/primitives/useSeriesPrimitive.test.tsx
+++ b/lib/src/primitives/useSeriesPrimitive.test.tsx
@@ -1,0 +1,95 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSafeContext } from "@/_shared/useSafeContext";
+import { useSeriesPrimitive } from "./useSeriesPrimitive";
+
+vi.mock("@/_shared/useSafeContext");
+
+const mockChart = {
+  api: () => ({}),
+};
+
+const mockAttachPrimitive = vi.fn();
+const mockDetachPrimitive = vi.fn();
+
+const mockSeries = {
+  api: () => ({
+    attachPrimitive: mockAttachPrimitive,
+    detachPrimitive: mockDetachPrimitive,
+  }),
+};
+
+describe("useSeriesPrimitive", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("initializes seriesPrimitive", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: true,
+      chartApiRef: mockChart,
+      seriesApiRef: mockSeries,
+    });
+
+    const { result } = renderHook(() =>
+      useSeriesPrimitive({
+        plugin: {},
+      })
+    );
+
+    const api = result.current.current.api();
+    expect(api).toBeDefined();
+  });
+
+  it("does not initialize seriesPrimitive if not ready", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: false,
+      chartApiRef: mockChart,
+      seriesApiRef: mockSeries,
+    });
+
+    const { result } = renderHook(() =>
+      useSeriesPrimitive({
+        plugin: {},
+      })
+    );
+
+    expect(result.current.current.api()).toBeNull();
+  });
+
+  it("calls render function if provided", () => {
+    const renderMock = vi.fn().mockReturnValue({});
+
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: true,
+      chartApiRef: mockChart,
+      seriesApiRef: mockSeries,
+    });
+
+    renderHook(() =>
+      useSeriesPrimitive({
+        render: renderMock,
+      })
+    );
+
+    expect(renderMock).toHaveBeenCalled();
+    expect(mockAttachPrimitive).toHaveBeenCalled();
+  });
+
+  it("clears primitive on unmount", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      isReady: true,
+      chartApiRef: mockChart,
+      seriesApiRef: mockSeries,
+    });
+
+    const { unmount } = renderHook(() =>
+      useSeriesPrimitive({
+        plugin: {},
+      })
+    );
+
+    unmount();
+    expect(mockDetachPrimitive).toHaveBeenCalled();
+  });
+});

--- a/lib/src/primitives/useSeriesPrimitive.ts
+++ b/lib/src/primitives/useSeriesPrimitive.ts
@@ -1,0 +1,49 @@
+import { useLayoutEffect, useRef } from "react";
+import { useSafeContext } from "@/_shared/useSafeContext";
+import { SeriesContext } from "@/series/SeriesContext";
+import type { SeriesPrimitiveApiRef, SeriesPrimitiveProps } from "./types";
+
+export const useSeriesPrimitive = ({ plugin }: SeriesPrimitiveProps) => {
+  const { isReady: seriesIsReady, seriesApiRef: series } = useSafeContext(SeriesContext);
+
+  const seriesPrimitiveApiRef = useRef<SeriesPrimitiveApiRef>({
+    _primitive: null,
+    api() {
+      return this._primitive;
+    },
+    init() {
+      if (!this._primitive) {
+        const seriesApi = series?.api();
+
+        if (!seriesApi) {
+          return null;
+        }
+
+        seriesApi.attachPrimitive(plugin);
+        this._primitive = plugin;
+      }
+
+      return this._primitive;
+    },
+    clear() {
+      if (this._primitive !== null) {
+        series?.api()?.detachPrimitive(this._primitive);
+        this._primitive = null;
+      }
+    },
+  });
+
+  useLayoutEffect(() => {
+    if (!seriesIsReady) return;
+
+    seriesPrimitiveApiRef.current.init();
+  }, [seriesIsReady]);
+
+  useLayoutEffect(() => {
+    return () => {
+      seriesPrimitiveApiRef.current.clear();
+    };
+  }, []);
+
+  return seriesPrimitiveApiRef;
+};

--- a/lib/src/scales/useTimeScale.ts
+++ b/lib/src/scales/useTimeScale.ts
@@ -14,10 +14,6 @@ export const useTimeScale = ({
   const { isReady: chartIsReady, chartApiRef: chart } = useSafeContext(ChartContext);
   const [isReady, setIsReady] = useState(false);
 
-  if (!chart) {
-    throw new Error("Chart context not found");
-  }
-
   const timeScaleApiRef = useRef<TimeScaleApiRef>({
     _timeScale: null,
     api() {

--- a/lib/src/series/SeriesTemplate.tsx
+++ b/lib/src/series/SeriesTemplate.tsx
@@ -1,7 +1,8 @@
 import { forwardRef, useImperativeHandle } from "react";
 import { SeriesContext } from "./SeriesContext";
 import { useSeries } from "./useSeries";
-import type { SeriesType, SeriesTemplateProps, SeriesApiRef } from "./types";
+import type { SeriesTemplateProps, SeriesApiRef } from "./types";
+import type { SeriesType } from "lightweight-charts";
 import type { ForwardedRef } from "react";
 
 type GenericSeriesComponent = (<T extends SeriesType>(
@@ -35,6 +36,5 @@ const SeriesTemplateRenderFunction = <T extends SeriesType>(
 };
 
 const SeriesTemplate = forwardRef(SeriesTemplateRenderFunction) as GenericSeriesComponent;
-
 SeriesTemplate.displayName = "SeriesTemplate";
 export { SeriesTemplate };

--- a/lib/src/series/index.ts
+++ b/lib/src/series/index.ts
@@ -5,4 +5,4 @@ export { AreaSeries } from "./AreaSeries";
 export { BaselineSeries } from "./BaselineSeries";
 export { BarSeries } from "./BarSeries";
 export { CustomSeries } from "./CustomSeries";
-export type { SeriesApiRef, SeriesType, SeriesProps, SeriesOptions } from "./types";
+export type { SeriesApiRef, SeriesProps, SeriesOptions } from "./types";

--- a/lib/src/series/types.ts
+++ b/lib/src/series/types.ts
@@ -3,10 +3,9 @@ import type {
   ISeriesApi,
   SeriesDataItemTypeMap,
   SeriesPartialOptionsMap,
+  SeriesType,
 } from "lightweight-charts";
 import type { ReactNode } from "react";
-
-export type SeriesType = keyof SeriesDataItemTypeMap;
 
 export type CustomSeriesUniqueProps = {
   plugin?: ICustomSeriesPaneView;

--- a/lib/src/series/useSeries.ts
+++ b/lib/src/series/useSeries.ts
@@ -11,13 +11,8 @@ import { BaseInternalError } from "@/_shared/InternalError";
 import { useSafeContext } from "@/_shared/useSafeContext";
 import { ChartContext } from "@/chart/ChartContext";
 import { incrementPaneCount, panesCount, decrementPaneCount } from "@/pane/panesCount";
-import type {
-  CustomSeriesUniqueProps,
-  SeriesApiRef,
-  SeriesTemplateProps,
-  SeriesType,
-} from "./types";
-import type { SeriesDefinition, ISeriesApi } from "lightweight-charts";
+import type { CustomSeriesUniqueProps, SeriesApiRef, SeriesTemplateProps } from "./types";
+import type { SeriesDefinition, ISeriesApi, SeriesType } from "lightweight-charts";
 
 type SeriesTypeWithoutCustom = Exclude<SeriesType, "Custom">;
 

--- a/lib/vitest.config.ts
+++ b/lib/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     include: ["src/**/*.test.{ts,tsx}"],
     globals: true,
     coverage: {
+      enabled: process.env.COVERAGE !== "false",
       provider: "v8",
       reporter: ["json", "text", "lcov"],
       include: ["src/**/*.{ts,tsx}"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "@mui/icons-material": "^6.4.10",
         "@mui/material": "^6.4.7",
         "@react-hook/resize-observer": "^2.0.2",
+        "@uiw/react-color-wheel": "^2.5.5",
         "copy-to-clipboard": "^3.3.3",
         "fancy-canvas": "^2.1.0",
         "lightweight-charts-react-components": "file:../lib",
@@ -3876,6 +3877,50 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@uiw/color-convert": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@uiw/color-convert/-/color-convert-2.5.5.tgz",
+      "integrity": "sha512-sNKhJe3h/nMxxoB3NEr02RTjkSE85sLIwQyl1lVK4scVCQumPbz1giWcWlYnSRLBHmrYYat7xShrDf/+Uc3UAg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0"
+      }
+    },
+    "node_modules/@uiw/react-color-wheel": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@uiw/react-color-wheel/-/react-color-wheel-2.5.5.tgz",
+      "integrity": "sha512-9waqaTdJgeZS5oc85NlKTVeVBSmBU2JypECoYPKqxRPlwetEWo/gJazAyU0HCpZqU5TucPRYUz6shRTz1On+0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@uiw/color-convert": "2.5.5",
+        "@uiw/react-drag-event-interactive": "2.5.5"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@uiw/react-drag-event-interactive": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@uiw/react-drag-event-interactive/-/react-drag-event-interactive-2.5.5.tgz",
+      "integrity": "sha512-RO31lRPh0pDFM++dTT42K5zrJsYb5kGy502Ou5aTIP/XJg05+Xy5QpF4o4EPsuzNJ1GOpPYg+V5FsvafQ+LONQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.19.0",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
       }
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -1,39 +1,23 @@
 #!/bin/bash
 
 # This script builds the lib and examples
-# It requires jq to be installed
 
 set -euo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 REPO_ROOT="$SCRIPT_DIR/.."
 LIB_PATH="lib"
-LIB_PACKAGE_JSON="$REPO_ROOT/lib/package.json"
-ROOT_PACKAGE_JSON="$REPO_ROOT/package.json"
-EXAMPLES_PATH="examples"
 
-# Build lib
-echo "Building lib..."
+echo -e "Setting env variables...\n"
+source "$SCRIPT_DIR/prepare-env.sh"
+
+echo -e "\nBuilding lib..."
 cd "$REPO_ROOT/$LIB_PATH"
 npm run build
 
-# Indicate examples build start
 echo "Building examples..."
 cd "$REPO_ROOT/$EXAMPLES_PATH"
-
-# Set required env to build examples
-echo "Setting env variables..."
-
-export VITE_LIGHTWEIGHT_CHARTS_REACT_COMPONENTS_VERSION=$(jq -r .version $LIB_PACKAGE_JSON | sed 's/[^0-9.]//g')
-echo "lighweight-charts-components-version: $VITE_LIGHTWEIGHT_CHARTS_REACT_COMPONENTS_VERSION"
-
-export VITE_LIGHTWEIGHT_CHARTS_VERSION=$(
-  jq -r '.dependencies["lightweight-charts"]' "$ROOT_PACKAGE_JSON" | sed 's/[^0-9.]//g'
-)
-echo "lightweight-charts-version: $VITE_LIGHTWEIGHT_CHARTS_VERSION"
-
-export VITE_GITHUB_URL=$(jq -r .repository $LIB_PACKAGE_JSON)
-echo "github-url: $VITE_GITHUB_URL"
-
 npm run build
 cd -
+
+echo "Building finished successfully."

--- a/scripts/prepare-env.sh
+++ b/scripts/prepare-env.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# This script prepares the environment variables needed for building examples
+
+set -e pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+REPO_ROOT="$SCRIPT_DIR/.."
+LIB_PACKAGE_JSON="$REPO_ROOT/lib/package.json"
+ROOT_PACKAGE_JSON="$REPO_ROOT/package.json"
+EXAMPLES_PATH="examples"
+
+export VITE_LIGHTWEIGHT_CHARTS_REACT_COMPONENTS_VERSION=$(jq -r .version $LIB_PACKAGE_JSON | sed 's/[^0-9.]//g')
+echo "lighweight-charts-components-version: $VITE_LIGHTWEIGHT_CHARTS_REACT_COMPONENTS_VERSION"
+
+export VITE_LIGHTWEIGHT_CHARTS_VERSION=$(
+  jq -r '.dependencies["lightweight-charts"]' "$ROOT_PACKAGE_JSON" | sed 's/[^0-9.]//g'
+)
+echo "lightweight-charts-version: $VITE_LIGHTWEIGHT_CHARTS_VERSION"
+
+export VITE_GITHUB_URL=$(jq -r .repository $LIB_PACKAGE_JSON)
+echo "github-url: $VITE_GITHUB_URL"


### PR DESCRIPTION
## Short Summary

<!-- Provide a brief summary of the changes introduced in this PR -->

This diff adds `SeriesPrimitive` component that can be used to draw [series primitive](https://tradingview.github.io/lightweight-charts/docs/plugins/series-primitives) on the chart.

## Changes made

<!-- Provide a detailed description of the changes introduced in this PR -->

-
-
-

## Related Issues

<!-- Mention the issues that are being closed by this PR -->

Fixes #84 
