### PR TITLE
chore: update types/node

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -13,6 +13,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@rslib/core"
         update-types: ["version-update:semver-minor"]
+      - dependency-name: "rsbuild-plugin-dts"
+        update-types: ["version-update:semver-minor"]
       - dependency-name: "vitest"
         update-types: ["version-update:semver-minor"]
     groups:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,4 +1,4 @@
-# 📦 Migration guide
+# Migration guide
 
 This guide explains how to upgrade to the latest version of `lightweight-charts-react-components`.
 If you're stuck, [open an issue](https://github.com/ukorvl/lightweight-charts-react-components/issues) or ask a question in the [discussions](https://github.com/ukorvl/lightweight-charts-react-components/discussions).

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/jsdom": "^21.1.7",
-        "@types/node": "^22.15.3",
+        "@types/node": "^24.0.13",
         "concurrently": "^9.1.2",
         "dotenv": "^17.2.0",
         "eslint": "^9.28.0",
@@ -3799,13 +3799,13 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "22.15.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
-      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+      "version": "24.0.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.13.tgz",
+      "integrity": "sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -12052,9 +12052,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/jsdom": "^21.1.7",
-    "@types/node": "^22.15.3",
+    "@types/node": "^24.0.13",
     "concurrently": "^9.1.2",
     "dotenv": "^17.2.0",
     "eslint": "^9.28.0",


### PR DESCRIPTION
## Short Summary

<!-- Provide a brief summary of the changes introduced in this PR -->

This diff updates `@types/node` package to match preferred nodejs version.

## Changes made

<!-- Provide a detailed description of the changes introduced in this PR -->

- Updates `@types/node`
- Makes dependabot ignore rslib-plugin-dts, because new versions are not compatible. We might migrate manually later.
