### PR TITLE
chore: add jsdoc comments to exported ts types

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -144,6 +144,8 @@ export default [
             // We can assume that all React components are functions starting with uppercase
             // We export only components, so we can skip the check for other functions
             "VariableDeclarator[id.name=/^[A-Z]/]",
+            "TSTypeAliasDeclaration",
+            "TSInterfaceDeclaration",
           ],
         },
       ],

--- a/lib/src/_shared/useSafeContext.ts
+++ b/lib/src/_shared/useSafeContext.ts
@@ -1,7 +1,7 @@
 import { type Context, useContext } from "react";
 import { BaseInternalError } from "./InternalError";
 
-export const useSafeContext = <T>(context: Context<T>, errorMessage?: string) => {
+const useSafeContext = <T>(context: Context<T>, errorMessage?: string) => {
   const currentContextValue = useContext(context);
 
   if (!currentContextValue) {
@@ -13,3 +13,5 @@ export const useSafeContext = <T>(context: Context<T>, errorMessage?: string) =>
 
   return currentContextValue;
 };
+
+export { useSafeContext };

--- a/lib/src/chart/types.ts
+++ b/lib/src/chart/types.ts
@@ -7,6 +7,9 @@ import {
 } from "lightweight-charts";
 import type { JSX, ReactNode } from "react";
 
+/**
+ * Chart component props.
+ */
 export type ChartProps = {
   children?: ReactNode;
   containerProps?: JSX.IntrinsicElements["div"];
@@ -17,6 +20,9 @@ export type ChartProps = {
   onDblClick?: MouseEventHandler<Time>;
 };
 
+/**
+ * Chart API reference type that can be used to access the chart plugin API.
+ */
 export type ChartApiRef = {
   _chart: IChartApi | null;
   api: () => IChartApi | null;
@@ -24,15 +30,24 @@ export type ChartApiRef = {
   clear: () => void;
 };
 
+/**
+ * Chart context that provides access to the chart API and readiness state.
+ */
 export interface IChartContext {
   chartApiRef: ChartApiRef | null;
   isReady: boolean;
 }
 
+/**
+ * Chart component properties that can be used to create a chart.
+ */
 export type ChartComponentProps = {
   container: HTMLElement;
 } & Omit<ChartProps, "containerProps">;
 
+/**
+ * Options for the useChart hook.
+ */
 export type UseChartOptions = {
   container: HTMLElement;
 } & Omit<ChartProps, "children" | "containerProps">;

--- a/lib/src/markers/types.ts
+++ b/lib/src/markers/types.ts
@@ -1,5 +1,8 @@
 import type { ISeriesMarkersPluginApi, SeriesMarker, Time } from "lightweight-charts";
 
+/**
+ * Markers API reference type that can be used to access the series markers plugin API.
+ */
 export type MarkersApiRef = {
   _markers: ISeriesMarkersPluginApi<Time> | null;
   api: () => ISeriesMarkersPluginApi<Time> | null;
@@ -7,6 +10,9 @@ export type MarkersApiRef = {
   clear: () => void;
 };
 
+/**
+ * Markers component properties that can be used to create a series markers component.
+ */
 export type MarkersProps = {
   markers: SeriesMarker<Time>[];
   reactive?: boolean;

--- a/lib/src/pane/types.ts
+++ b/lib/src/pane/types.ts
@@ -1,11 +1,17 @@
 import type { IPaneApi, Time } from "lightweight-charts";
 import type { ReactNode } from "react";
 
+/**
+ * Pane component props.
+ */
 export type PaneProps = {
   children?: ReactNode;
   stretchFactor?: number;
 };
 
+/**
+ * Pane API reference type that can be used to access the pane plugin API.
+ */
 export type PaneApiRef = {
   _pane: IPaneApi<Time> | null;
   api: () => IPaneApi<Time> | null;
@@ -13,6 +19,9 @@ export type PaneApiRef = {
   clear: () => void;
 };
 
+/**
+ * Pane context that provides access to the pane API and readiness state.
+ */
 export interface IPaneContext {
   paneApiRef?: PaneApiRef;
   isReady: boolean;

--- a/lib/src/priceLine/types.ts
+++ b/lib/src/priceLine/types.ts
@@ -1,10 +1,16 @@
 import type { IPriceLine, PriceLineOptions } from "lightweight-charts";
 
+/**
+ * PriceLine component props.
+ */
 export type PriceLineProps = {
   price: number;
   options?: Omit<Partial<PriceLineOptions>, "price">;
 };
 
+/**
+ * PriceLine API reference type that can be used to access the price line plugin API.
+ */
 export type PriceLineApiRef = {
   _priceLine: IPriceLine | null;
   api: () => IPriceLine | null;

--- a/lib/src/primitives/types.ts
+++ b/lib/src/primitives/types.ts
@@ -5,6 +5,9 @@ import type {
   SeriesType,
 } from "lightweight-charts";
 
+/**
+ * Series primitive API reference type that can be used to access the series primitive plugin API.
+ */
 export type SeriesPrimitiveApiRef = {
   _primitive: ISeriesPrimitive | null;
   api(): ISeriesPrimitive | null;
@@ -12,6 +15,9 @@ export type SeriesPrimitiveApiRef = {
   clear(): void;
 };
 
+/**
+ * Render function type for series primitives.
+ */
 export type RenderPrimitive<T extends SeriesType = SeriesType> = ({
   chart,
   series,
@@ -30,6 +36,9 @@ type SeriesPrimitivePropsWithPlugin = {
   render?: never;
 };
 
+/**
+ * Series primitive properties that can be used to create a series primitive.
+ */
 export type SeriesPrimitiveProps<T extends SeriesType = SeriesType> =
   | SeriesPrimitivePropsWithRender<T>
   | SeriesPrimitivePropsWithPlugin;

--- a/lib/src/scales/types.ts
+++ b/lib/src/scales/types.ts
@@ -15,6 +15,9 @@ import type { DependencyList, ReactNode } from "react";
 type TimeScaleOptions = DeepPartial<TimeScaleNativeOptions>;
 type PriceScaleOptions = DeepPartial<PriceScaleNativeOptions>;
 
+/**
+ * Time scale API reference type that can be used to access the time scale plugin API.
+ */
 export type TimeScaleApiRef = {
   _timeScale: ITimeScaleApi<Time> | null;
   api: () => ITimeScaleApi<Time> | null;
@@ -22,6 +25,9 @@ export type TimeScaleApiRef = {
   clear: () => void;
 };
 
+/**
+ * Price scale API reference type that can be used to access the price scale plugin API.
+ */
 export type PriceScaleApiRef = {
   _priceScale: IPriceScaleApi | null;
   api: () => IPriceScaleApi | null;
@@ -30,6 +36,9 @@ export type PriceScaleApiRef = {
   clear: () => void;
 };
 
+/**
+ * TimeScale component props.
+ */
 export type TimeScaleProps = {
   onVisibleTimeRangeChange?: TimeRangeChangeEventHandler<Time>;
   onVisibleLogicalRangeChange?: LogicalRangeChangeEventHandler;
@@ -40,15 +49,24 @@ export type TimeScaleProps = {
   children?: ReactNode;
 };
 
+/**
+ * PriceScale component props.
+ */
 export type PriceScaleProps = {
   options?: PriceScaleOptions;
   id: string;
 };
 
+/**
+ * TimeScaleFitContentTriggerProps component props.
+ */
 export type TimeScaleFitContentTriggerProps = {
   deps: DependencyList;
 };
 
+/**
+ * TimeScaleContext that provides access to the time scale API and readiness state.
+ */
 export interface ITimeScaleContext {
   timeScaleApiRef: TimeScaleApiRef | null;
   isReady: boolean;

--- a/lib/src/series/types.ts
+++ b/lib/src/series/types.ts
@@ -7,6 +7,9 @@ import type {
 } from "lightweight-charts";
 import type { ReactNode } from "react";
 
+/**
+ * Unique properties for the custom series component.
+ */
 export type CustomSeriesUniqueProps = {
   plugin?: ICustomSeriesPaneView;
 };
@@ -17,11 +20,17 @@ type SeriesParameters<T extends SeriesType> = {
   options?: SeriesOptions<T>;
 } & (T extends "Custom" ? CustomSeriesUniqueProps : {});
 
+/**
+ * Properties of a series template component that can be used to create a series of a specific type.
+ */
 export type SeriesTemplateProps<T extends SeriesType> = {
   type: T;
   children?: ReactNode;
 } & SeriesParameters<T>;
 
+/**
+ * Series API reference type that can be used to access the series plugin API.
+ */
 export type SeriesApiRef<T extends SeriesType> = {
   _series: ISeriesApi<T> | null;
   api: () => ISeriesApi<T> | null;
@@ -29,11 +38,20 @@ export type SeriesApiRef<T extends SeriesType> = {
   clear: () => void;
 };
 
+/**
+ * Context for the series component that provides access to the series API and readiness state.
+ */
 export interface ISeriesContext {
   seriesApiRef: SeriesApiRef<SeriesType> | null;
   isReady: boolean;
 }
 
+/**
+ * Series options that can be used to customize the appearance and behavior of a series.
+ */
 export type SeriesOptions<T extends SeriesType> = SeriesPartialOptionsMap[T];
 
+/**
+ * Series component properties that can be used to create a series of a specific type.
+ */
 export type SeriesProps<T extends SeriesType> = Omit<SeriesTemplateProps<T>, "type">;

--- a/lib/src/watermark/types.ts
+++ b/lib/src/watermark/types.ts
@@ -7,14 +7,28 @@ import type {
   Time,
 } from "lightweight-charts";
 
+/**
+ * Watermark types supported by the library.
+ * - `text`: A text watermark.
+ * - `image`: An image watermark.
+ */
 export type WatermarkType = "text" | "image";
 
+/**
+ * Unique properties for the text watermark component.
+ */
 export type TextWatermarkProps = DeepPartial<TextWatermarkOptions>;
 
+/**
+ * Unique properties for the image watermark component.
+ */
 export type ImageWatermarkProps = {
   src: string;
 } & DeepPartial<ImageWatermarkOptions>;
 
+/**
+ * Watermark component properties that can be used to create either a text or image watermark.
+ */
 export type WatermarkProps<T extends WatermarkType> = {
   type: T;
 } & (T extends "text" ? TextWatermarkProps : ImageWatermarkProps);
@@ -33,6 +47,9 @@ type WatermarkImageApiRefBase = {
   clear: () => void;
 };
 
+/**
+ * Watermark API reference type that can be used to access the watermark plugin API.
+ */
 export type WatermarkApiRef<T extends WatermarkType> = T extends "text"
   ? WatermarkTextApiRefBase
   : WatermarkImageApiRefBase;


### PR DESCRIPTION
## Short Summary

This diff adds jsdoc comment to public ts types and makes them required to pass linting.

## Related Issues

<!-- Mention the issues that are being closed by this PR -->

Fixes #187 