### PR TITLE
feat: add series order prop

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- add `seriesOrder` prop to all series components to control series rendering order
 
 ## [1.1.1] - 2025-07-23
 ### Added

--- a/lib/src/series/types.ts
+++ b/lib/src/series/types.ts
@@ -18,6 +18,7 @@ type SeriesParameters<T extends SeriesType> = {
   data: SeriesDataItemTypeMap[T][];
   reactive?: boolean;
   options?: SeriesOptions<T>;
+  seriesOrder?: ReturnType<ISeriesApi<T>["seriesOrder"]>;
 } & (T extends "Custom" ? CustomSeriesUniqueProps : {});
 
 /**

--- a/lib/src/series/useSeries.test.tsx
+++ b/lib/src/series/useSeries.test.tsx
@@ -16,14 +16,17 @@ vi.mock("@/pane/usePaneContext", () => ({
 }));
 
 const mockApplyOptions = vi.fn();
+const mockSetSeriesOrder = vi.fn();
 const mockAddSeries = vi.fn().mockReturnValue({
   setData: vi.fn(),
   applyOptions: mockApplyOptions,
+  setSeriesOrder: mockSetSeriesOrder,
 });
 const mockRemoveSeries = vi.fn();
 const mockAddCustomSeries = vi.fn().mockReturnValue({
   setData: vi.fn(),
   applyOptions: mockApplyOptions,
+  setSeriesOrder: mockSetSeriesOrder,
 });
 
 const mockChart = {
@@ -220,5 +223,22 @@ describe("useSeries", () => {
         })
       )
     ).toThrow("Custom series requires a plugin to be defined");
+  });
+
+  it("should set series order if provided", () => {
+    vi.mocked(useSafeContext).mockReturnValue({
+      chartApiRef: mockChart,
+      isReady: true,
+    });
+
+    renderHook(() =>
+      useSeries({
+        type: "Line",
+        data: [],
+        seriesOrder: 1,
+      })
+    );
+
+    expect(mockSetSeriesOrder).toHaveBeenCalledWith(1);
   });
 });

--- a/lib/src/series/useSeries.ts
+++ b/lib/src/series/useSeries.ts
@@ -21,6 +21,7 @@ export const useSeries = <T extends SeriesType>({
   data,
   options = {},
   reactive = true,
+  seriesOrder,
   ...rest
 }: Omit<SeriesTemplateProps<T>, "children">) => {
   const { isReady: chartIsReady, chartApiRef: chart } = useSafeContext(ChartContext);
@@ -63,6 +64,9 @@ export const useSeries = <T extends SeriesType>({
         }
 
         this._series?.setData(data);
+        if (seriesOrder !== undefined) {
+          this._series?.setSeriesOrder(seriesOrder);
+        }
         setIsReady(true);
       }
 
@@ -108,6 +112,14 @@ export const useSeries = <T extends SeriesType>({
       seriesApiRef.current.api()?.applyOptions(options);
     }
   }, [options]);
+
+  useLayoutEffect(() => {
+    if (!chart) return;
+
+    if (seriesOrder !== undefined) {
+      seriesApiRef.current.api()?.setSeriesOrder(seriesOrder);
+    }
+  }, [seriesOrder]);
 
   return { isReady, seriesApiRef };
 };


### PR DESCRIPTION
## Short Summary

<!-- Provide a brief summary of the changes introduced in this PR -->

This diff adds `seriesOrder` prop to series component to reflect series order api (https://tradingview.github.io/lightweight-charts/docs/api/interfaces/ISeriesApi#seriesorder)

## Related Issues

<!-- Mention the issues that are being closed by this PR -->

Fixes #69 
