### PR TITLE
chore: add lazy with retry

### DIFF
--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -1,11 +1,12 @@
-import { lazy, Suspense } from "react";
+import { Suspense } from "react";
 import { Route, Router, Switch } from "wouter";
+import { lazyWithRetry } from "./common/lazyWithRetry";
 import { Layout } from "./Layout";
 import { Index } from "./pages/index/Index";
 import { Page404 } from "./pages/Page404";
 import { ProgressBox } from "./ui/ProgressBox";
 
-const Terminal = lazy(() => import("./pages/Terminal"));
+const Terminal = lazyWithRetry(() => import("./pages/Terminal"), "Terminal");
 
 const TerminalLazy = () => {
   return (

--- a/examples/src/common/lazyWithRetry.ts
+++ b/examples/src/common/lazyWithRetry.ts
@@ -1,0 +1,29 @@
+import { lazy } from "react";
+
+type ComponentImportType = () => Promise<{ default: React.ComponentType }>;
+
+const sessionKey = "lazyWithRetry";
+
+const lazyWithRetry = (componentImport: ComponentImportType, name: string) => {
+  return lazy(async () => {
+    const hasRefreshed = sessionStorage.getItem(`${sessionKey}-${name}`) || "false";
+
+    try {
+      sessionStorage.setItem(`${sessionKey}-${name}`, "false");
+      return await componentImport();
+    } catch (error) {
+      if (hasRefreshed === "false") {
+        sessionStorage.setItem(`${sessionKey}-${name}`, "true");
+        window.location.reload();
+      }
+
+      if (hasRefreshed === "true") {
+        const errorMessage = error instanceof Error ? error.message : "Unknown error";
+        throw new Error("chunkLoadError: " + errorMessage);
+      }
+    }
+    return await componentImport();
+  });
+};
+
+export { lazyWithRetry };

--- a/examples/src/pages/index/Index.tsx
+++ b/examples/src/pages/index/Index.tsx
@@ -1,10 +1,11 @@
 import { Link, Stack, Typography, Box } from "@mui/material";
-import { lazy, Suspense } from "react";
+import { Suspense } from "react";
+import { lazyWithRetry } from "@/common/lazyWithRetry";
 import { logoKeyframes, textBgKeyframes } from "@/common/styles";
 import { ProgressBox } from "@/ui/ProgressBox";
 import { colors } from "../../common/colors";
 
-const Contents = lazy(() => import("./Contents"));
+const Contents = lazyWithRetry(() => import("./Contents"), "Contents");
 
 export const Index = () => {
   const {


### PR DESCRIPTION
## Short Summary

<!-- Provide a brief summary of the changes introduced in this PR -->

This diff adds `lazyWithRetry` utility to handle the case when asset is updated on the server but in service worked the previous version is still opened in a tab. When user tries to navigate - they will receive an error "chunk not found".