### PR TITLE
feat: series update api

### DIFF
--- a/examples/src/samples/RealTime/RealTime.tsx
+++ b/examples/src/samples/RealTime/RealTime.tsx
@@ -74,7 +74,7 @@ const RealTime = () => {
         options={chartCommonOptions}
         ref={ref}
       >
-        <CandlestickSeries data={structuredClone(data)} reactive={reactive} />
+        <CandlestickSeries data={data} reactive={reactive} />
         <TimeScale>
           <TimeScaleFitContentTrigger deps={resizeOnUpdate ? [data.length] : []} />
         </TimeScale>

--- a/lib/src/series/types.ts
+++ b/lib/src/series/types.ts
@@ -22,6 +22,12 @@ type SeriesParameters<T extends SeriesType> = {
   reactive?: boolean;
   options?: SeriesOptions<T>;
   seriesOrder?: ReturnType<ISeriesApi<T>["seriesOrder"]>;
+  /**
+   * If true, the series will replace its data on every update.
+   * If false, it will try to append data to the existing series, that can be useful for performance.
+   *
+   * @see {@link https://tradingview.github.io/lightweight-charts/docs#updating-the-data-in-a-series | TradingView documentation for updating series data}
+   */
   alwaysReplaceData?: boolean;
 } & (T extends "Custom" ? CustomSeriesUniqueProps : {});
 

--- a/lib/src/series/useSeries.ts
+++ b/lib/src/series/useSeries.ts
@@ -110,19 +110,21 @@ export const useSeries = <T extends SeriesType>({
 
       const currentData = seriesApi.data();
       const dataLengthDifference = data.length - currentData.length;
+      const maxIncrementalUpdateThreshold = 1;
       const shouldReplaceData =
         alwaysReplaceData ||
-        seriesApi.data().length === 0 ||
+        currentData.length === 0 ||
         data.length === 0 ||
         dataLengthDifference < 0 ||
-        dataLengthDifference > 1;
+        dataLengthDifference > maxIncrementalUpdateThreshold;
 
       if (shouldReplaceData) {
         seriesApi.setData(data);
         return;
       }
 
-      seriesApi.update(data[data.length - 1]);
+      const lastDataPoint = { ...data[data.length - 1] };
+      seriesApi.update(lastDataPoint);
     }
   }, [data, reactive, alwaysReplaceData]);
 


### PR DESCRIPTION
## Short Summary

<!-- Provide a brief summary of the changes introduced in this PR -->

This diff optimizes the performance of `<Series />` component under the hood. It uses series [update](https://tradingview.github.io/lightweight-charts/docs#updating-the-data-in-a-series) method when possible in order to avoid full data replacement, which improves performance especially on big data sets or frequent real-time updates.

 A new copy of data item to add is created every time because LWC `series.update()` api mutates the object. If provide it by reference - our data is going to be mutated implicitly. So it is a minor trade-off to prevent potential issues.

## Related Issues

<!-- Mention the issues that are being closed by this PR -->

Related to #206 
