### PR TITLE
Let lightweight-charts mutate data by default

### DIFF
--- a/examples/src/samples/RealTime/RealTime.tsx
+++ b/examples/src/samples/RealTime/RealTime.tsx
@@ -28,6 +28,7 @@ const RealTime = () => {
     ref: ref as RefObject<HTMLDivElement>,
     margin: "100px",
   });
+  const clonedData = structuredClone(data); // to avoid mutation by the chart library
 
   useEffect(() => {
     if (isOnScreen) {
@@ -74,7 +75,7 @@ const RealTime = () => {
         options={chartCommonOptions}
         ref={ref}
       >
-        <CandlestickSeries data={data} reactive={reactive} />
+        <CandlestickSeries data={clonedData} reactive={reactive} />
         <TimeScale>
           <TimeScaleFitContentTrigger deps={resizeOnUpdate ? [data.length] : []} />
         </TimeScale>

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- let `lightweight-charts` handle data mutation internally, instead of cloning data on every update
+
 ## [1.3.0] - 2025-07-31
 ### Added
 - add `alwaysReplaceData` prop to all series components to control data update behavior

--- a/lib/src/series/useSeries.ts
+++ b/lib/src/series/useSeries.ts
@@ -123,7 +123,7 @@ export const useSeries = <T extends SeriesType>({
         return;
       }
 
-      const lastDataPoint = { ...data[data.length - 1] };
+      const lastDataPoint = data[data.length - 1];
       seriesApi.update(lastDataPoint);
     }
   }, [data, reactive, alwaysReplaceData]);


### PR DESCRIPTION
## Short Summary

<!-- Provide a brief summary of the changes introduced in this PR -->

The default behavior of `lightweight-charts` is to mutate the data passed to `series.update()`. And it appropriate for many scenarios.
So i decided to remove the cloning of data item from the core library and let it work as `lightweight-charts` works. If the mutation of data is unacceptable (for instance it is a store), developers can avoid this side-effect by providing a new data object.
The pros of that decision is the optimization of charts updates and eliminating unnecessary complexity. 

## Changes made

<!-- Provide a detailed description of the changes introduced in this PR -->

- let `lightweight-charts` handle data mutation internally, instead of cloning data on every update
