### PR TITLE
fix: time scale visible range throw error value is null if you have pane

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - let `lightweight-charts` handle data mutation internally, instead of cloning data on every update
+- fix `TimeScale` prop `visibleRange` error "Value is null" when series are inside `Pane`
 
 ## [1.3.0] - 2025-07-31
 ### Added

--- a/lib/src/scales/useTimeScale.ts
+++ b/lib/src/scales/useTimeScale.ts
@@ -1,6 +1,7 @@
 import { useLayoutEffect, useRef, useState } from "react";
 import { useSafeContext } from "@/_shared/useSafeContext";
 import { ChartContext } from "@/chart/ChartContext";
+import { usePaneContext } from "@/pane/usePaneContext";
 import type { TimeScaleApiRef, TimeScaleProps } from "./types";
 
 export const useTimeScale = ({
@@ -12,6 +13,7 @@ export const useTimeScale = ({
   options = {},
 }: Omit<TimeScaleProps, "children">) => {
   const { isReady: chartIsReady, chartApiRef: chart } = useSafeContext(ChartContext);
+  const { isPaneReady, isInsidePane } = usePaneContext();
   const [isReady, setIsReady] = useState(false);
 
   const timeScaleApiRef = useRef<TimeScaleApiRef>({
@@ -67,8 +69,12 @@ export const useTimeScale = ({
   useLayoutEffect(() => {
     if (!chartIsReady) return;
 
+    if (isInsidePane && !isPaneReady) {
+      return;
+    }
+
     timeScaleApiRef.current.init();
-  }, [chartIsReady]);
+  }, [chartIsReady, isInsidePane, isPaneReady]);
 
   useLayoutEffect(() => {
     return () => {


### PR DESCRIPTION
## Short Summary
Fixed `TimeScale `component error "Value is null" when setting `visibleRange` prop while series are inside a `Pane` component. The issue occurred due to timing problems where `setVisibleRange` was called before series data was ready.

## Changes made
- Initialize `timeScale` only if parent `Pane` is ready

## Testing steps
1. Open `/examples/src/samples/InfiniteData/InfiniteData.tsx`
2. Add ``` visibleRange={{
              from: data[data.length - 10].time,
              to: data[data.length - 1].time,
            }}``` as `<TimeScale>` prop

Before the change:
**Error: Value is null**
<img width="353" height="71" alt="image" src="https://github.com/user-attachments/assets/48085ab1-5ce3-4d68-8df3-e141b7553332" />

After the change:
No errors. The chart displays the correct selected range.
<img width="758" height="599" alt="image" src="https://github.com/user-attachments/assets/b1e09b70-ced8-4ab6-b6d5-3df415606ff7" />

