### PR TITLE
chore: v2.1.0

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.1.0] - 2026-05-20
 ### Changed
 - extend wrapper-exposed upstream types for the `lightweight-charts` `v5.0.9` additions: chart and time scale options now include `rightOffsetPixels`, marker options include `autoScale`, series price format options include `base`, and chart/series refs expose the updated `takeScreenshot()`, `pop()`, and `lastValueData()` APIs
 

--- a/lib/jsr.json
+++ b/lib/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukorvl/lightweight-charts-react-components",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "$schema": "https://jsr.io/schema/config-file.v1.json",
   "license": "MIT",
   "exports": "./src/index.ts",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightweight-charts-react-components",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",

--- a/lib/src/version.ts
+++ b/lib/src/version.ts
@@ -1,1 +1,1 @@
-export const version = "2.0.0";
+export const version = "2.1.0";

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,7 @@
     },
     "lib": {
       "name": "lightweight-charts-react-components",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.1",


### PR DESCRIPTION
This pull request updates the project to version 2.1.0, reflecting the addition of new features and API extensions from the `lightweight-charts` library version 5.0.9. The changes include updating version numbers across relevant files and documenting the new features in the changelog.

Version and documentation updates:

* Updated the version number to `2.1.0` in `package.json`, `jsr.json`, and `src/version.ts` to reflect the new release. [[1]](diffhunk://#diff-1e946220773aef913945326261b7ee8d08b8ec29ccc66ef7c348950439212ffbL3-R3) [[2]](diffhunk://#diff-e4dea3135c2550200ead35c04ba2829758b3f156abf7892b039bda25bfad3c2dL3-R3) [[3]](diffhunk://#diff-753dcd7c7cbd6e1355e8fffb41a1a392482b37619ff15b6687f96996fe90d311L1-R1)
* Added a new entry to the `CHANGELOG.md` for version 2.1.0, documenting the extension of wrapper-exposed upstream types and new API options and methods from `lightweight-charts` v5.0.9.