### PR TITLE
Chore: minor release manager skill fixes

### DIFF
--- a/.agents/skills/release-manager/SKILL.md
+++ b/.agents/skills/release-manager/SKILL.md
@@ -1,52 +1,65 @@
 ---
 name: release-manager
-description: "Prepare semver releases for this repository. Use when Codex needs to create or resume a `release-vX.Y.Z` branch from `main`, bump the library version by `major`, `minor`, or `patch`, verify `lib/package.json`, `lib/jsr.json`, and `lib/src/version.ts` stay in sync, update release-facing docs such as `lib/CHANGELOG.md`, `MIGRATION.md`, `SECURITY.md`, and READMEs when needed, run release validation, create commit `chore: vX.Y.Z`, and add annotated tag `vX.Y.Z`."
+description: "Prepare or finalize semver releases for this repository. Use when Codex needs to create or resume a `release-vX.Y.Z` branch from `main`, bump the library version by `major`, `minor`, or `patch`, verify `lib/package.json`, `lib/jsr.json`, `lib/src/version.ts`, and the library entry in `package-lock.json` stay in sync, update release-facing docs such as `lib/CHANGELOG.md`, `MIGRATION.md`, `SECURITY.md`, and READMEs when needed, run release validation, create commit `chore: vX.Y.Z`, open a release PR, and only after maintainer confirmation create or push annotated tag `vX.Y.Z` from the reviewed release commit."
 ---
 
 # Release Manager
 
 Use this skill to prepare a local release branch and the git artifacts needed before a maintainer runs the repository's GitHub `Release` workflow.
 
-## Inputs`
+## Inputs
 
 Collect these inputs from the request or infer them from context:
 
+- `mode`: `prepare-release-branch` or `finalize-release-tag`; default to `prepare-release-branch`
 - `bump`: `major`, `minor`, or `patch`
 - `repo_path`: repository root; default the current workspace if it contains `lib/package.json`
 - `base_branch`: default `main`
 - `remote`: default `origin`
-- `push_and_pr`: optional; only if the user wants the release branch pushed and a PR opened after local prep
+- `push_and_pr`: optional; only for `prepare-release-branch`
+- `release_ref`: required for `finalize-release-tag` unless the user clearly identifies the reviewed commit or merged `main` HEAD that should be tagged
+- `push_tag`: optional; only for `finalize-release-tag` after explicit maintainer confirmation
 
 If the worktree already contains unrelated edits, pause and ask before continuing. Release prep should start from a clean tree so the release commit does not absorb unrelated work.
+
+## Modes
+
+Choose the mode first and keep the semantics explicit.
+
+- `prepare-release-branch`: create or resume the release branch, bump files, update docs, validate, commit, and optionally open the PR. Do not create or push the release tag in this mode.
+- `finalize-release-tag`: work only from the reviewed release commit after merge approval. Create the annotated tag on that reviewed commit, push it only when the maintainer confirms, and then let the maintainer run the GitHub `Release` workflow on that tag.
 
 ## Workflow
 
 1. Read `references/release-checklist.md` before changing files if the repository layout looks unfamiliar.
 2. Use the repo's required environment: `nvm use` for Node 24, and `npm` only.
-3. Run `scripts/prepare_release.sh --repo <repo_path> --bump <bump>`.
+3. If `mode` is `prepare-release-branch`, run `scripts/prepare_release.sh --repo <repo_path> --bump <bump>`.
    - It computes the target version from `lib/package.json`.
    - It updates `main` from `origin/main` unless `--skip-fetch` is needed.
    - It creates or resumes `release-vX.Y.Z`.
    - It runs the repository version bump entrypoint only if the release branch still has the base version.
-   - It verifies the version trio matches after the branch switch and bump.
-4. Update release documentation.
+   - It verifies all version touchpoints match after the branch switch and bump, including the library entry in `package-lock.json`.
+4. If `mode` is `prepare-release-branch`, update release documentation.
    - Always update `lib/CHANGELOG.md`.
    - Update `MIGRATION.md` for breaking changes or new upgrade steps.
    - Update `SECURITY.md` when supported major lines change.
    - Inspect other markdown files such as `README.md`, `lib/README.md`, `examples/README.md`, and `CONTRIBUTING.md` when the release changes public API, install guidance, or release workflow notes.
-5. Validate the release branch.
+5. If `mode` is `prepare-release-branch`, validate the release branch.
    - Always run `scripts/check_versions_in_sync.sh --repo <repo_path>`.
    - Choose the rest of the checks from `references/release-checklist.md` based on what changed.
    - Before handing off a ready release branch, prefer the repo-level quality gates if feasible: `npm run build`, `npm run lint`, `npm run format`, and `npm run knip`.
-6. Create the git artifacts.
+6. If `mode` is `prepare-release-branch`, create the release commit.
    - Stage only release-related files.
    - Create commit `chore: vX.Y.Z`.
-   - Create annotated tag `vX.Y.Z` with message `release vX.Y.Z`.
-   - Never recreate or move an existing release tag. Stop and report if the tag already exists locally or on the remote.
-7. Optional GitHub flow.
-   - If the user wants the full review flow, push `release-vX.Y.Z` and open a PR to `main`.
+   - If the user wants the review flow, push `release-vX.Y.Z` and open a PR to `main`.
    - Mention that the repository posts release-note previews on PRs whose branch name starts with `release`.
-   - Do not publish or run the GitHub `Release` workflow unless the user explicitly asks.
+   - Do not create or push the release tag in this mode.
+7. If `mode` is `finalize-release-tag`, work from the reviewed release commit only.
+   - Confirm the exact commit or ref to tag. Prefer the merged commit on `main` or another reviewed ref explicitly approved by the maintainer.
+   - Verify the tag does not already exist locally or on the remote.
+   - Create annotated tag `vX.Y.Z` with message `release vX.Y.Z` on that reviewed commit.
+   - Push the tag only when the maintainer confirms.
+   - Run or trigger the GitHub `Release` workflow on that tag only when the user explicitly asks.
 
 ## Files To Read On Demand
 
@@ -60,5 +73,7 @@ If the worktree already contains unrelated edits, pause and ask before continuin
 - Do not rewrite or discard unrelated user changes.
 - Prefer `git switch` and `git pull --ff-only`; avoid destructive resets.
 - If the release branch already exists with the target version, reuse it instead of bumping twice.
+- Never create or push a release tag from an unreviewed local-only release branch.
+- Tag only after PR review and maintainer confirmation of the exact commit being released.
 - If documentation updates are unclear, inspect the source changes and existing changelog style before writing notes.
 - If a new major release changes supported lines, make sure `SECURITY.md` reflects the new support policy.

--- a/.agents/skills/release-manager/agents/openai.yaml
+++ b/.agents/skills/release-manager/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Release Manager"
   short_description: "Prepare repo release branches and tags"
-  default_prompt: "Use $release-manager to prepare a patch, minor, or major release in /path/to/repo."
+  default_prompt: "Use $release-manager to prepare a release branch or finalize a reviewed release tag in /path/to/repo."

--- a/.agents/skills/release-manager/references/release-checklist.md
+++ b/.agents/skills/release-manager/references/release-checklist.md
@@ -5,10 +5,11 @@
 - Runtime: Node 24 from `.nvmrc`
 - Package manager: `npm` only
 - Version bump entrypoint: `npm run version -- <major|minor|patch>`
-- Version files that must match:
+- Version-related files normally changed by a release:
   - `lib/package.json`
   - `lib/jsr.json`
   - `lib/src/version.ts`
+  - `package-lock.json`
 - Release workflows to mirror locally:
   - `.github/actions/check-versions-in-sync/action.yaml`
   - `.github/workflows/check-changelog.yaml`
@@ -47,12 +48,21 @@
 
 ## Git flow
 
-- Ensure `main` is up to date with `origin/main`
-- Create or resume `release-vX.Y.Z`
+- Recommended order:
+  - create or resume `release-vX.Y.Z`
+  - commit `chore: vX.Y.Z`
+  - open PR to `main`
+  - review and merge
+  - identify the reviewed commit to release
+  - create annotated tag `vX.Y.Z` on that reviewed commit
+  - push the tag
+  - run the GitHub `Release` workflow on that tag
+- Ensure `main` is up to date with `origin/main` before branch prep or tag finalization
 - Keep the release commit message exactly `chore: vX.Y.Z`
-- Create the annotated tag with `git tag -a vX.Y.Z -m "release vX.Y.Z"`
+- Never create or push the release tag from an unreviewed local-only release branch
 - Check for existing tags before creating a new one:
   - local: `git rev-parse -q --verify refs/tags/vX.Y.Z`
   - remote: `git ls-remote --tags origin vX.Y.Z`
 - Push and open a PR to `main` only when the user asks for that extra step
+- Push the tag only after the maintainer confirms the reviewed commit that should be released
 - Do not run publish commands or the GitHub `Release` workflow unless the user explicitly asks

--- a/.agents/skills/release-manager/scripts/check_versions_in_sync.sh
+++ b/.agents/skills/release-manager/scripts/check_versions_in_sync.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: check_versions_in_sync.sh --repo <path> [--package-json lib/package.json] [--jsr-json lib/jsr.json] [--version-file lib/src/version.ts]
+Usage: check_versions_in_sync.sh --repo <path> [--package-json lib/package.json] [--jsr-json lib/jsr.json] [--version-file lib/src/version.ts] [--package-lock package-lock.json] [--lock-package-key lib]
 EOF
 }
 
@@ -44,10 +44,30 @@ read_ts_version() {
   ' "$1"
 }
 
+read_lockfile_package_version() {
+  node --input-type=module -e '
+    import { readFileSync } from "node:fs";
+
+    const file = process.argv[1];
+    const packageKey = process.argv[2];
+    const json = JSON.parse(readFileSync(file, "utf8"));
+    const version = json.packages?.[packageKey]?.version;
+
+    if (!version) {
+      console.error(`Error: Could not read package-lock version for ${packageKey} from ${file}`);
+      process.exit(1);
+    }
+
+    process.stdout.write(String(version));
+  ' "$1" "$2"
+}
+
 REPO_PATH=""
 PACKAGE_JSON="lib/package.json"
 JSR_JSON="lib/jsr.json"
 VERSION_FILE="lib/src/version.ts"
+PACKAGE_LOCK="package-lock.json"
+LOCK_PACKAGE_KEY="lib"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -65,6 +85,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --version-file)
       VERSION_FILE="$2"
+      shift 2
+      ;;
+    --package-lock)
+      PACKAGE_LOCK="$2"
+      shift 2
+      ;;
+    --lock-package-key)
+      LOCK_PACKAGE_KEY="$2"
       shift 2
       ;;
     -h|--help)
@@ -91,8 +119,9 @@ REPO_PATH=$(cd "$REPO_PATH" && pwd)
 PACKAGE_JSON_PATH="$REPO_PATH/$PACKAGE_JSON"
 JSR_JSON_PATH="$REPO_PATH/$JSR_JSON"
 VERSION_FILE_PATH="$REPO_PATH/$VERSION_FILE"
+PACKAGE_LOCK_PATH="$REPO_PATH/$PACKAGE_LOCK"
 
-for file in "$PACKAGE_JSON_PATH" "$JSR_JSON_PATH"; do
+for file in "$PACKAGE_JSON_PATH" "$JSR_JSON_PATH" "$PACKAGE_LOCK_PATH"; do
   if [[ ! -f "$file" ]]; then
     echo "Error: Missing required file $file." >&2
     exit 1
@@ -101,9 +130,15 @@ done
 
 PACKAGE_VERSION=$(read_json_version "$PACKAGE_JSON_PATH")
 JSR_VERSION=$(read_json_version "$JSR_JSON_PATH")
+LOCKFILE_VERSION=$(read_lockfile_package_version "$PACKAGE_LOCK_PATH" "$LOCK_PACKAGE_KEY")
 
 if [[ "$JSR_VERSION" != "$PACKAGE_VERSION" ]]; then
   echo "Error: jsr.json version ($JSR_VERSION) does not match package.json version ($PACKAGE_VERSION)." >&2
+  exit 1
+fi
+
+if [[ "$LOCKFILE_VERSION" != "$PACKAGE_VERSION" ]]; then
+  echo "Error: package-lock version for $LOCK_PACKAGE_KEY ($LOCKFILE_VERSION) does not match package.json version ($PACKAGE_VERSION)." >&2
   exit 1
 fi
 

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.cursor/skills
+++ b/.cursor/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,9 @@ Thumbs.db
 playwright-report/
 
 # skills
-.agents/skills
-.claude/skills
-.cursor/skills
+.agents/skills/*
 skills-lock.json
+
+# repo-native skills that should not be ignored
+!.agents/skills/release-manager/
+!.agents/skills/release-manager/**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ Thank you for helping keep this project and its users safe!
 | Version | Supported          |
 | ------- | ------------------ |
 | 2.x     | :white_check_mark: |
-| 1.x     | :x: |
+| 1.x     | :x:                |
 | < 1.0   | :x:                |
 
 Unsupported versions are not actively maintained and may contain known vulnerabilities.


### PR DESCRIPTION
This pull request enhances the release management process to make release branch preparation and tag finalization more robust and auditable. It introduces explicit modes for preparing a release branch versus finalizing a release tag, ensures all relevant version files (including `package-lock.json`) are kept in sync, and clarifies the workflow to prevent unreviewed releases. The documentation and scripts have been updated accordingly.

**Release workflow improvements:**

* The release manager skill now distinguishes between two modes: `prepare-release-branch` (for preparing and reviewing release branches) and `finalize-release-tag` (for tagging a reviewed commit only after maintainer confirmation). The workflow and documentation have been updated to clarify these steps and prevent accidental or unreviewed tagging. [[1]](diffhunk://#diff-8b528c605b3cb44e88f8b15cd7191a24879bfe829928c2bc40fcf5d8db2ae577L3-R62) [[2]](diffhunk://#diff-8b528c605b3cb44e88f8b15cd7191a24879bfe829928c2bc40fcf5d8db2ae577R76-R77) [[3]](diffhunk://#diff-38f4b103c3d0bcb78c3442fcab1db19bf18f526d5383b4ce7e51c4f411ec61c2L4-R4) [[4]](diffhunk://#diff-99cc54aa270f0193af0d801f47da76493aadaa2c5b17faf1b2ccbb54fb85cfdcL50-R67)

**Version file synchronization:**

* The release scripts and checklist now require that the library entry in `package-lock.json` is updated and matches the version in `lib/package.json`, `lib/jsr.json`, and `lib/src/version.ts`. The `check_versions_in_sync.sh` script has been updated to check this automatically. [[1]](diffhunk://#diff-8b528c605b3cb44e88f8b15cd7191a24879bfe829928c2bc40fcf5d8db2ae577L3-R62) [[2]](diffhunk://#diff-99cc54aa270f0193af0d801f47da76493aadaa2c5b17faf1b2ccbb54fb85cfdcL8-R12) [[3]](diffhunk://#diff-191219cc50b9e5820c45f279f08584d2d2672c8924696af8127caa08b6d64f49L7-R7) [[4]](diffhunk://#diff-191219cc50b9e5820c45f279f08584d2d2672c8924696af8127caa08b6d64f49R47-R70) [[5]](diffhunk://#diff-191219cc50b9e5820c45f279f08584d2d2672c8924696af8127caa08b6d64f49R90-R97) [[6]](diffhunk://#diff-191219cc50b9e5820c45f279f08584d2d2672c8924696af8127caa08b6d64f49R122-R124) [[7]](diffhunk://#diff-191219cc50b9e5820c45f279f08584d2d2672c8924696af8127caa08b6d64f49R133-R144)

**Stronger safeguards and guidance:**

* The documentation now explicitly warns never to create or push a release tag from an unreviewed local-only branch, and to only tag after PR review and explicit maintainer confirmation. [[1]](diffhunk://#diff-8b528c605b3cb44e88f8b15cd7191a24879bfe829928c2bc40fcf5d8db2ae577R76-R77) [[2]](diffhunk://#diff-99cc54aa270f0193af0d801f47da76493aadaa2c5b17faf1b2ccbb54fb85cfdcL50-R67)

These changes help ensure releases are consistent, auditable, and only finalized after proper review.